### PR TITLE
fix(fast-mode): avoid @effect/platform-node barrel to prevent ioredis crash

### DIFF
--- a/.changeset/fast-mode-ioredis-barrel.md
+++ b/.changeset/fast-mode-ioredis-barrel.md
@@ -1,0 +1,5 @@
+---
+'@pi-plugins/fast-mode': patch
+---
+
+Import `NodeServices` from its deep subpath instead of the `@effect/platform-node` barrel, so loading the extension no longer eagerly evaluates `NodeRedis` and crashes with `Cannot find module 'ioredis'` when the optional `ioredis` peer dependency is absent.

--- a/plugins/fast-mode/src/index.ts
+++ b/plugins/fast-mode/src/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
-import { NodeServices } from '@effect/platform-node'
+import * as NodeServices from '@effect/platform-node/NodeServices'
 import { loadExtensionConfig } from '@pi-plugins/shared'
 import {
   Array,


### PR DESCRIPTION
## Problem

Starting Pi with the fast-mode extension installed crashed at load time:

```
Error: Failed to load extension ".../@pi-plugins/fast-mode/dist/index.mjs": Cannot find module 'ioredis'
Require stack:
- .../@effect/platform-node/dist/NodeRedis.js
```

## Root cause

The extension imported `NodeServices` from the `@effect/platform-node` **barrel**:

```ts
import { NodeServices } from '@effect/platform-node'
```

ESM eagerly evaluates the barrel's entire re-export graph — not just `NodeServices`. That graph includes `export * as NodeRedis from "./NodeRedis.js"`, and `NodeRedis.js` does a top-level `import * as IoRedis from "ioredis"`. `ioredis` is only an **optional peer** dependency of `@effect/platform-node`, so a plain `npm install` into `~/.pi/agent/npm` doesn't pull it — and loading the extension throws before any of our code runs. pnpm happened to resolve the peer in this repo, which is why it built and ran fine locally.

## Fix

Import `NodeServices` from its deep subpath so only that module (and its clean filesystem/path/etc. deps) is evaluated; `NodeRedis`/`ioredis` never enter the module graph:

```ts
import * as NodeServices from '@effect/platform-node/NodeServices'
```

The package's `"./*": "./dist/*.js"` export resolves this directly to `dist/NodeServices.js`, with a matching `.d.ts`, so types and `NodeServices.layer` are unchanged.

## Verification

- Rebuilt `dist/index.mjs`; confirmed no `ioredis`/`NodeRedis` references remain in the bundle.
- Full `ci` passes (lint, type-check, format, build).
- Confirmed no other plugin/tooling source imports the `@effect/platform-node` barrel.

A `patch` changeset for `@pi-plugins/fast-mode` is included so the release flow versions and publishes the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)