### PR TITLE
fix(fast-mode): render fast indicator inline on the footer model line

### DIFF
--- a/.changeset/fast-mode-footer-indicator.md
+++ b/.changeset/fast-mode-footer-indicator.md
@@ -1,0 +1,5 @@
+---
+'@pi-plugins/fast-mode': patch
+---
+
+Render the active `fast` indicator inline on the footer's model line — as a dim `• fast` after the effort level — instead of on a separate, undimmed status row. Reuses pi's built-in footer via a live view over the extension context and appends the suffix flush against the right edge, so it matches the surrounding gray and stays right-aligned across resizes and effort changes.

--- a/plugins/fast-mode/src/index.ts
+++ b/plugins/fast-mode/src/index.ts
@@ -1,4 +1,8 @@
-import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
+import {
+  FooterComponent,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from '@earendil-works/pi-coding-agent'
 import * as NodeServices from '@effect/platform-node/NodeServices'
 import { loadExtensionConfig } from '@pi-plugins/shared'
 import {
@@ -15,6 +19,8 @@ import {
 
 const EXTENSION_ID = 'fast-mode'
 const COMMAND_ARGS = ['on', 'off', 'status'] as const
+/** Appended after the effort level on the footer's model line while active. */
+const FAST_SUFFIX = ' • fast'
 
 const FastModeConfig = Schema.Struct({
   enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -74,6 +80,7 @@ function applyOpenAIPriorityTier(
 export default function fastMode(pi: ExtensionAPI) {
   let config = Schema.decodeUnknownSync(FastModeConfig)({})
   let enabled = false
+  let footerInstalled = false
 
   function checkEligibility(model: ExtensionContext['model']): Eligibility {
     if (!model) {
@@ -98,13 +105,56 @@ export default function fastMode(pi: ExtensionAPI) {
   }
 
   function updateStatus(ctx: ExtensionContext): void {
-    if (ctx.hasUI && config.showStatus) {
-      const eligibility = checkEligibility(ctx.model)
-      ctx.ui.setStatus(
-        EXTENSION_ID,
-        enabled && Eligibility.$is('Eligible')(eligibility) ? 'fast' : undefined,
-      )
+    if (!ctx.hasUI || !config.showStatus) {
+      return
     }
+
+    const active =
+      enabled && Eligibility.$is('Eligible')(checkEligibility(ctx.model))
+    if (active === footerInstalled) {
+      return
+    }
+    footerInstalled = active
+
+    // Reuse pi's built-in footer via a live view over `ctx`, then append a dim
+    // `• fast` after the effort level on the model line. Rendering the inner
+    // footer a suffix-width narrower keeps that line right-aligned once we add it.
+    ctx.ui.setFooter(
+      active
+        ? (tui, theme, footerData) => {
+            const session = {
+              get state() {
+                return { model: ctx.model, thinkingLevel: pi.getThinkingLevel() }
+              },
+              get sessionManager() {
+                return ctx.sessionManager
+              },
+              get modelRegistry() {
+                return ctx.modelRegistry
+              },
+              getContextUsage: () => ctx.getContextUsage(),
+            } as unknown as ConstructorParameters<typeof FooterComponent>[0]
+
+            const inner = new FooterComponent(session, footerData)
+            const unsubscribe = footerData.onBranchChange(() => tui.requestRender())
+
+            return {
+              invalidate: () => inner.invalidate(),
+              dispose: () => {
+                unsubscribe()
+                inner.dispose()
+              },
+              render: (width) => {
+                const lines = inner.render(Math.max(width - FAST_SUFFIX.length, 0))
+                if (width > FAST_SUFFIX.length && lines.length > 1) {
+                  lines[1] += theme.fg('dim', FAST_SUFFIX)
+                }
+                return lines
+              },
+            }
+          }
+        : undefined,
+    )
   }
 
   function notifyState(ctx: ExtensionContext): void {


### PR DESCRIPTION
## What

Moves the `fast` indicator from its own footer row to the bottom-right **model line**, appended after the effort level as a dim `• fast`:

```
~/nixos (master)
$0.000 (sub) 0.0%/272k (auto)   (openai-codex) gpt-5.5 • xhigh • fast
```

## Why

The previous `ctx.ui.setStatus(...)` call put `fast` on a separate line that pi's built-in footer renders **un-dimmed and left-aligned** — so it looked detached from the rest of the footer and stood out in the wrong color.

## How

There's no API to append to the built-in footer's model line, so this switches to `ctx.ui.setFooter()`. Rather than reimplement the footer's token/cost/context math, it **reuses pi's exported `FooterComponent`** driven by a thin live view over the extension context (`state` ← `ctx.model` + `pi.getThinkingLevel()`, plus `sessionManager`/`modelRegistry`/`getContextUsage`). The inner footer is rendered one suffix-width narrower and ` • fast` is appended flush against the right edge, keeping the model line right-aligned across resizes and effort changes.

The custom footer is installed only while fast mode is **active and eligible**; otherwise the built-in footer is restored unchanged.

### Known limitations
- Couples to `FooterComponent`'s public export and the session fields it reads; upstream footer changes could require a tweak (but visuals track upstream for free in the common case).
- The clone can't read the live auto-compact toggle (not exposed to extensions), so it defaults to showing `(auto)` — same limitation a hand-written copy would have.

## Testing

Manual, in the pi TUI (no LLM request needed — the footer depends only on the selected model + toggle):

```bash
pnpm --filter @pi-plugins/fast-mode build
pi -e ./plugins/fast-mode/dist/index.mjs --fast
```

- `/fast on` / `off` → suffix appears/disappears; footer reverts to built-in when off
- switch to a non-configured model → suffix disappears; switch back → returns
- resize terminal + change effort → suffix stays flush-right and updates live

`ci` passes (format, lint, type-check, build). Build confirms `@earendil-works/pi-coding-agent` stays externalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)