### PR TITLE
refactor(subagent): model run failures as typed errors in the Effect error channel

### DIFF
--- a/.changeset/subagent-typed-errors.md
+++ b/.changeset/subagent-typed-errors.md
@@ -1,0 +1,10 @@
+---
+'@pi-plugins/subagent': patch
+---
+
+Model subagent run failures as typed errors in the Effect error channel instead
+of folding them into the success value. `runSubagent` now succeeds only with the
+final run snapshot and fails with self-describing tagged errors
+(`SubagentStopError`, `SubagentExitError`, `SubagentNoOutputError`, or the
+underlying `PlatformError`), which the tool maps onto failed tool calls in a
+single generic handler at the usage site.

--- a/plugins/subagent/src/index.ts
+++ b/plugins/subagent/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from '@pi-plugins/shared'
 import { Effect } from 'effect'
 import { Type, type Static } from 'typebox'
-import { isFailure, runSubagent, type SubagentSnapshot } from './runner'
+import { emptySnapshot, runSubagent, type SubagentSnapshot } from './runner'
 import { capToolOutput, formatUsage, modelPattern } from './utils'
 
 const PROMPT_PREVIEW_LINES = 2
@@ -40,8 +40,10 @@ const subagentSchema = Type.Object({
 export type SubagentInput = Static<typeof subagentSchema>
 
 interface SubagentDetails extends SubagentSnapshot {
-  exitCode?: number
-  stderr?: string
+  /** Set on the final result when the run failed. */
+  failed?: boolean | undefined
+  errorMessage?: string | undefined
+  stderr?: string | undefined
 }
 
 export default function subagent(pi: ExtensionAPI) {
@@ -82,37 +84,42 @@ export default function subagent(pi: ExtensionAPI) {
             details: snapshot,
           })
         },
-      }).pipe(Effect.provide(NodeServices.layer))
-
-      const result = await Effect.runPromise(program, { signal })
-
-      if (isFailure(result)) {
-        const reason =
-          result.errorMessage ||
-          result.stderr.trim() ||
-          result.output ||
-          `pi exited with code ${result.exitCode}`
-        return {
+      }).pipe(
+        Effect.map((snapshot) => ({
           content: [
             {
-              type: 'text',
-              text: `Subagent ${result.stopReason ?? 'failed'}: ${capToolOutput(reason)}`,
+              type: 'text' as const,
+              text: snapshot.output ? capToolOutput(snapshot.output) : '(no output)',
             },
           ],
-          details: result,
-          isError: true,
-        }
-      }
+          details: snapshot as SubagentDetails,
+        })),
+        Effect.catch((error) => {
+          const label = error._tag === 'SubagentStopError' ? error.reason : 'failed'
+          const reason =
+            error._tag === 'PlatformError'
+              ? `Failed to run subagent: ${error.message}`
+              : error.message
+          return Effect.succeed({
+            content: [
+              {
+                type: 'text' as const,
+                text: `Subagent ${label}: ${capToolOutput(reason)}`,
+              },
+            ],
+            details: {
+              ...('snapshot' in error ? error.snapshot : emptySnapshot),
+              failed: true,
+              errorMessage: reason,
+              stderr: 'stderr' in error ? error.stderr : undefined,
+            },
+            isError: true,
+          })
+        }),
+        Effect.provide(NodeServices.layer),
+      )
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: result.output ? capToolOutput(result.output) : '(no output)',
-          },
-        ],
-        details: result,
-      }
+      return await Effect.runPromise(program, { signal })
     },
     renderCall(args, theme) {
       let text =
@@ -143,12 +150,8 @@ export default function subagent(pi: ExtensionAPI) {
       return new Text(text, 0, 0)
     },
     renderResult({ details }, { expanded, isPartial }, theme, context) {
-      const running = isPartial || details.exitCode === undefined
-      const failed =
-        !running &&
-        (details.exitCode !== 0 ||
-          details.stopReason === 'error' ||
-          details.stopReason === 'aborted')
+      const running = isPartial
+      const failed = details.failed === true
 
       if (!running) {
         stopSpinner(context.state)
@@ -167,14 +170,15 @@ export default function subagent(pi: ExtensionAPI) {
       } else if (running) {
         header += ` ${theme.fg('muted', 'starting...')}`
       }
-      if (failed && details.errorMessage) {
-        header += `\n${theme.fg('error', `Error: ${details.errorMessage}`)}`
-      }
-
       const content =
         details.output ||
         (failed ? (details.stderr?.trim() ?? '') : '') ||
         (running ? '(running...)' : '(no output)')
+
+      // Skip the error line when it would repeat the rendered content.
+      if (failed && details.errorMessage && details.errorMessage !== content) {
+        header += `\n${theme.fg('error', `Error: ${details.errorMessage}`)}`
+      }
 
       const text = new Text('', 0, 0)
       text.setText(renderExpandableText({ header, content, expanded, theme }))

--- a/plugins/subagent/src/runner.ts
+++ b/plugins/subagent/src/runner.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { Effect, Fiber, Filter, Schema, Stream } from 'effect'
+import { Data, Effect, Fiber, Filter, Schema, Stream } from 'effect'
+import type { PlatformError } from 'effect/PlatformError'
 import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
 
 /** Cap on buffered stderr (in characters) so a pathological child can't exhaust memory. */
@@ -20,33 +21,76 @@ export interface SubagentUsage {
   contextTokens: number
 }
 
-/** Live progress of a running subagent, emitted after every completed message. */
+/**
+ * Progress of a subagent run, emitted after every completed message and
+ * returned as the final value of a successful run.
+ */
 export interface SubagentSnapshot {
-  /** Text of the most recent assistant message. */
   output: string
   toolCalls: number
   usage: SubagentUsage
   model?: string | undefined
-  stopReason?: string | undefined
-  errorMessage?: string | undefined
 }
 
-/** Final outcome of a subagent run. */
-export interface SubagentResult extends SubagentSnapshot {
-  exitCode: number
-  stderr: string
+export const emptySnapshot: SubagentSnapshot = {
+  output: '',
+  toolCalls: 0,
+  usage: {
+    turns: 0,
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    cost: 0,
+    contextTokens: 0,
+  },
 }
 
-export interface RunSubagentOptions {
-  prompt: string
-  /** Optional model override, passed to `pi --model`. */
-  model?: string | undefined
-  /** Working directory for the spawned pi process. */
-  cwd?: string | undefined
-  /** Tool allowlist for the child. */
-  tools?: ReadonlyArray<string> | undefined
-  /** Called with a fresh snapshot whenever the subagent completes a message. */
-  onUpdate?: ((snapshot: SubagentSnapshot) => void) | undefined
+/**
+ * The subagent stopped without completing its task: the child reported an
+ * `error` or `aborted` stop reason on its final assistant message.
+ */
+export class SubagentStopError extends Data.TaggedError('SubagentStopError')<{
+  readonly reason: 'error' | 'aborted'
+  /** Error detail reported by the child, if any. */
+  readonly errorMessage?: string | undefined
+  readonly stderr: string
+  /** Progress made up to the failure. */
+  readonly snapshot: SubagentSnapshot
+}> {
+  override readonly message: string =
+    this.errorMessage ||
+    this.stderr.trim() ||
+    this.snapshot.output ||
+    `run stopped (${this.reason})`
+}
+
+/** The pi child process exited with a nonzero exit code. */
+export class SubagentExitError extends Data.TaggedError('SubagentExitError')<{
+  readonly exitCode: number
+  readonly stderr: string
+  /** Progress made up to the failure. */
+  readonly snapshot: SubagentSnapshot
+}> {
+  override readonly message: string =
+    this.stderr.trim() ||
+    this.snapshot.output ||
+    `pi exited with code ${this.exitCode}`
+}
+
+/**
+ * The child exited cleanly but emitted no assistant messages, meaning it
+ * produced no usable output (wrong invocation, polluted stdout, JSON format
+ * drift, ...).
+ */
+export class SubagentNoOutputError extends Data.TaggedError(
+  'SubagentNoOutputError',
+)<{
+  readonly stderr: string
+}> {
+  override readonly message: string =
+    'Subagent produced no assistant messages (unexpected or empty JSON event stream)' +
+    (this.stderr.trim() ? `\nstderr: ${this.stderr.trim()}` : '')
 }
 
 /**
@@ -85,25 +129,18 @@ const AssistantMessageEnd = Schema.fromJsonString(
 
 type AssistantMessage = (typeof AssistantMessageEnd)['Type']['message']
 
-const initialSnapshot: SubagentSnapshot = {
-  output: '',
-  toolCalls: 0,
-  usage: {
-    turns: 0,
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    cost: 0,
-    contextTokens: 0,
-  },
+/** Fold state: the public snapshot plus the child's last reported stop info. */
+interface RunState {
+  snapshot: SubagentSnapshot
+  stopReason?: string | undefined
+  errorMessage?: string | undefined
 }
 
-/** Folds one completed assistant message into the snapshot. */
-function foldMessage(
-  snapshot: SubagentSnapshot,
-  message: AssistantMessage,
-): SubagentSnapshot {
+const initialState: RunState = { snapshot: emptySnapshot }
+
+/** Folds one completed assistant message into the run state. */
+function foldMessage(state: RunState, message: AssistantMessage): RunState {
+  const { snapshot } = state
   let toolCalls = snapshot.toolCalls
   const texts: string[] = []
   for (const part of message.content) {
@@ -118,20 +155,22 @@ function foldMessage(
 
   const usage = message.usage
   return {
-    output,
-    toolCalls,
-    usage: {
-      turns: snapshot.usage.turns + 1,
-      input: snapshot.usage.input + (usage?.input ?? 0),
-      output: snapshot.usage.output + (usage?.output ?? 0),
-      cacheRead: snapshot.usage.cacheRead + (usage?.cacheRead ?? 0),
-      cacheWrite: snapshot.usage.cacheWrite + (usage?.cacheWrite ?? 0),
-      cost: snapshot.usage.cost + (usage?.cost?.total ?? 0),
-      contextTokens: usage?.totalTokens ?? snapshot.usage.contextTokens,
+    snapshot: {
+      output,
+      toolCalls,
+      usage: {
+        turns: snapshot.usage.turns + 1,
+        input: snapshot.usage.input + (usage?.input ?? 0),
+        output: snapshot.usage.output + (usage?.output ?? 0),
+        cacheRead: snapshot.usage.cacheRead + (usage?.cacheRead ?? 0),
+        cacheWrite: snapshot.usage.cacheWrite + (usage?.cacheWrite ?? 0),
+        cost: snapshot.usage.cost + (usage?.cost?.total ?? 0),
+        contextTokens: usage?.totalTokens ?? snapshot.usage.contextTokens,
+      },
+      model: message.model ?? snapshot.model,
     },
-    model: message.model ?? snapshot.model,
-    stopReason: message.stopReason ?? snapshot.stopReason,
-    errorMessage: message.errorMessage ?? snapshot.errorMessage,
+    stopReason: message.stopReason ?? state.stopReason,
+    errorMessage: message.errorMessage ?? state.errorMessage,
   }
 }
 
@@ -161,15 +200,23 @@ function resolvePiInvocation(args: ReadonlyArray<string>): {
 
 /**
  * Runs one headless pi instance for the given prompt and folds its JSONL
- * event stream into a `SubagentResult`.
- *
- * The prompt is piped via stdin to avoid argv length limits. Interruption
- * kills the child via the enclosing scope, and spawn/stream failures are
- * folded into a failed result instead of an error channel.
+ * event stream into a `SubagentSnapshot`.
  */
-export function runSubagent(
-  options: RunSubagentOptions,
-): Effect.Effect<SubagentResult, never, ChildProcessSpawner.ChildProcessSpawner> {
+export function runSubagent(options: {
+  prompt: string
+  /** Optional model override, passed to `pi --model`. */
+  model?: string | undefined
+  /** Working directory for the spawned pi process. */
+  cwd?: string | undefined
+  /** Tool allowlist for the child. */
+  tools?: ReadonlyArray<string> | undefined
+  /** Called with a fresh snapshot whenever the subagent completes a message. */
+  onUpdate?: ((snapshot: SubagentSnapshot) => void) | undefined
+}): Effect.Effect<
+  SubagentSnapshot,
+  SubagentStopError | SubagentExitError | SubagentNoOutputError | PlatformError,
+  ChildProcessSpawner.ChildProcessSpawner
+> {
   return Effect.scoped(
     Effect.gen(function* () {
       // `--exclude-tools subagent` prevents children from recursively
@@ -205,7 +252,7 @@ export function runSubagent(
         },
       )
 
-      options.onUpdate?.(initialSnapshot)
+      options.onUpdate?.(emptySnapshot)
 
       const stderrFiber = yield* Effect.forkScoped(
         handle.stderr.pipe(
@@ -220,7 +267,7 @@ export function runSubagent(
         ),
       )
 
-      const finalSnapshot = yield* handle.stdout.pipe(
+      const state = yield* handle.stdout.pipe(
         Stream.decodeText,
         Stream.splitLines,
         Stream.filterMap(
@@ -229,55 +276,36 @@ export function runSubagent(
           ),
         ),
         Stream.runFoldEffect(
-          () => initialSnapshot,
-          (snapshot, event) =>
+          () => initialState,
+          (previous, event) =>
             Effect.sync(() => {
-              const next = foldMessage(snapshot, event.message)
-              options.onUpdate?.(next)
+              const next = foldMessage(previous, event.message)
+              options.onUpdate?.(next.snapshot)
               return next
             }),
         ),
       )
 
-      const exitCode = yield* handle.exitCode
+      const exitCode = Number(yield* handle.exitCode)
       const stderr = yield* Fiber.join(stderrFiber)
+      const { snapshot } = state
 
-      // A clean exit without a single decoded assistant message means the
-      // child produced no usable output (wrong invocation, polluted stdout,
-      // JSON format drift, ...).
-      if (Number(exitCode) === 0 && finalSnapshot.usage.turns === 0) {
-        const detail = stderr.trim()
-        return {
-          ...finalSnapshot,
-          stopReason: 'error',
-          errorMessage:
-            'Subagent produced no assistant messages (unexpected or empty JSON event stream)' +
-            (detail.length > 0 ? `\nstderr: ${detail}` : ''),
-          exitCode: Number(exitCode),
+      if (state.stopReason === 'error' || state.stopReason === 'aborted') {
+        return yield* new SubagentStopError({
+          reason: state.stopReason,
+          errorMessage: state.errorMessage,
           stderr,
-        }
+          snapshot,
+        })
+      }
+      if (exitCode !== 0) {
+        return yield* new SubagentExitError({ exitCode, stderr, snapshot })
+      }
+      if (snapshot.usage.turns === 0) {
+        return yield* new SubagentNoOutputError({ stderr })
       }
 
-      return { ...finalSnapshot, exitCode: Number(exitCode), stderr }
+      return snapshot
     }),
-  ).pipe(
-    Effect.catch((error) =>
-      Effect.succeed<SubagentResult>({
-        ...initialSnapshot,
-        stopReason: 'error',
-        errorMessage: `Failed to run subagent: ${error.message}`,
-        exitCode: 1,
-        stderr: '',
-      }),
-    ),
-  )
-}
-
-/** Whether a finished run should be reported to the model as a failure. */
-export function isFailure(result: SubagentResult): boolean {
-  return (
-    result.exitCode !== 0 ||
-    result.stopReason === 'error' ||
-    result.stopReason === 'aborted'
   )
 }

--- a/tooling/lint/index.ts
+++ b/tooling/lint/index.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   plugins: ['oxc', 'typescript', 'unicorn', 'import'],
   rules: {
     curly: ['error', 'all'],
+    // `_tag` is the idiomatic discriminant of Effect's tagged types.
+    'no-underscore-dangle': 'off',
     'no-unused-vars': [
       'error',
       {


### PR DESCRIPTION
## Summary

Refactors the subagent plugin's error handling to use Effect's typed error channel instead of folding failures into the success value.

### `runner.ts`

- `runSubagent` now returns `Effect<SubagentSnapshot, SubagentError | PlatformError, ChildProcessSpawner>`: the success channel holds only real success data (output, tool calls, usage, model) — the old `SubagentResult` with `exitCode`/`stopReason`/`errorMessage` smuggled through the success value is gone.
- Each failure mode is an explicit tagged error carrying exactly its own facts, raised inline where they occur (no `mapError` wrapping, no post-hoc classification helper):
  - `SubagentStopError` — child reported an `error`/`aborted` stop reason
  - `SubagentExitError` — nonzero exit code
  - `SubagentNoOutputError` — clean exit but no usable output
  - `PlatformError` — spawn/stream failures flow through untouched
- Errors are self-describing: `message` is derived from the error's own fields on the class, so they render usefully anywhere Effect surfaces them (Cause pretty-printing, logs, spans).

### `index.ts`

- Success and failure are mapped onto tool results inside the pipeline; all failures collapse into a single generic `Effect.catch` handler since the errors self-describe — only the label and which payloads an error carries vary per tag.
- `SubagentDetails` gains an explicit `failed` discriminant for the renderer instead of inferring failure from a fake exit code.

### `tooling/lint`

- Disables `no-underscore-dangle` in the shared oxlint config: `_tag` is the idiomatic discriminant of Effect's tagged types.

## Validation

- `ci` (format, lint, type-check, build) passes.