### PR TITLE
subagent: make tool rows static and expose the child session id

### DIFF
--- a/.changeset/static-subagent-rows.md
+++ b/.changeset/static-subagent-rows.md
@@ -1,8 +1,12 @@
 ---
 '@pi-plugins/subagent': minor
+'@pi-plugins/webfetch': patch
 ---
 
 Stop redrawing subagent rows while the child runs: a row now paints when the child
 reports its session id and when the run ends, instead of streaming stats and thinking
 traces that dragged pi's viewport around. Children persist a named session in
 `~/.pi/agent/sessions/subagents/`, so `pi --session <id>` opens what a subagent did.
+
+Collapsed result previews are now capped at wrapped terminal rows rather than source
+lines, so prose output no longer previews as a wall of text next to a three-row prompt.

--- a/.changeset/static-subagent-rows.md
+++ b/.changeset/static-subagent-rows.md
@@ -6,5 +6,3 @@ Stop redrawing subagent rows while the child runs: a row now paints when the chi
 reports its session id and when the run ends, instead of streaming stats and thinking
 traces that dragged pi's viewport around. Children persist a named session in
 `~/.pi/agent/sessions/subagents/`, so `pi --session <id>` opens what a subagent did.
-A collapsed row previews the prompt and the result at a fixed number of wrapped
-terminal rows, so neither half grows with how the text happens to be shaped.

--- a/.changeset/static-subagent-rows.md
+++ b/.changeset/static-subagent-rows.md
@@ -1,12 +1,10 @@
 ---
 '@pi-plugins/subagent': minor
-'@pi-plugins/webfetch': patch
 ---
 
 Stop redrawing subagent rows while the child runs: a row now paints when the child
 reports its session id and when the run ends, instead of streaming stats and thinking
 traces that dragged pi's viewport around. Children persist a named session in
 `~/.pi/agent/sessions/subagents/`, so `pi --session <id>` opens what a subagent did.
-
-Collapsed result previews are now capped at wrapped terminal rows rather than source
-lines, so prose output no longer previews as a wall of text next to a three-row prompt.
+A collapsed row previews the prompt and the result at a fixed number of wrapped
+terminal rows, so neither half grows with how the text happens to be shaped.

--- a/.changeset/static-subagent-rows.md
+++ b/.changeset/static-subagent-rows.md
@@ -2,11 +2,7 @@
 '@pi-plugins/subagent': minor
 ---
 
-Make subagent tool rows static and expose the child's session id. A row now paints
-twice — when the child reports its session id and when the run ends — instead of
-streaming live stats and thinking traces that dragged pi's viewport around. Child runs
-persist a real session, named after the call's `description`, in
-`~/.pi/agent/sessions/subagents/`, so `pi --session <id>` opens what a subagent did
-without those sessions leaking into `pi -c` / `pi -r` for the project. The result block
-lists cwd, model and the full session id, and the completed run reports turns, tool
-calls, tokens, cost and wall-clock duration.
+Stop redrawing subagent rows while the child runs: a row now paints when the child
+reports its session id and when the run ends, instead of streaming stats and thinking
+traces that dragged pi's viewport around. Children persist a named session in
+`~/.pi/agent/sessions/subagents/`, so `pi --session <id>` opens what a subagent did.

--- a/.changeset/static-subagent-rows.md
+++ b/.changeset/static-subagent-rows.md
@@ -1,0 +1,12 @@
+---
+'@pi-plugins/subagent': minor
+---
+
+Make subagent tool rows static and expose the child's session id. A row now paints
+twice — when the child reports its session id and when the run ends — instead of
+streaming live stats and thinking traces that dragged pi's viewport around. Child runs
+persist a real session, named after the call's `description`, in
+`~/.pi/agent/sessions/subagents/`, so `pi --session <id>` opens what a subagent did
+without those sessions leaking into `pi -c` / `pi -r` for the project. The result block
+lists cwd, model and the full session id, and the completed run reports turns, tool
+calls, tokens, cost and wall-clock duration.

--- a/.changeset/webfetch-wrapped-row-preview.md
+++ b/.changeset/webfetch-wrapped-row-preview.md
@@ -1,0 +1,7 @@
+---
+'@pi-plugins/webfetch': patch
+---
+
+Cap the collapsed result preview at five wrapped terminal rows. It previously showed
+ten source lines, which for a fetched page is ten paragraphs and wrapped to a wall of
+text.

--- a/plugins/subagent/README.md
+++ b/plugins/subagent/README.md
@@ -36,29 +36,6 @@ pi -e ./plugins/subagent
 | `model`       | no       | Model override for this agent (passed to `pi --model`)                 |
 | `cwd`         | no       | Working directory for the agent process (defaults to the parent's cwd) |
 
-## The tool row
-
-The row does not stream: it paints when the child reports its session id, and again
-when the run ends.
-
-```text
-subagent Investigate the failing test
-  Investigate why the auth integration test fails on CI but passes locally. Look
-  at the test setup, the fixtures it loads and any environment differences
-  between the CI container and a dev machine.
-  ... (4 more lines, ctrl+o to expand)
-
-  cwd      /some/other/path
-  model    anthropic/claude-sonnet-4-5:high
-  session  019fd2ff-cca1-7a91-866c-7eedf6bc222c
-
-  ✓ 4 turns 12 tools ↑12k ↓3.0k $0.0412 1m22s
-  Root cause: the CI image pins an older openssl, so the fixture's certificate...
-```
-
-`cwd` shows only when it differs from the parent's. `ctrl+o` expands the prompt and
-the output.
-
 ## Sessions
 
 Children persist a session named after the call's `description`, so

--- a/plugins/subagent/README.md
+++ b/plugins/subagent/README.md
@@ -38,9 +38,8 @@ pi -e ./plugins/subagent
 
 ## The tool row
 
-The row does not stream. It paints twice — once when the child reports its session
-id, once when the run ends — so subagents that scroll out of view never drag the
-viewport around:
+The row does not stream: it paints when the child reports its session id, and again
+when the run ends.
 
 ```text
 subagent Investigate the failing test
@@ -57,25 +56,13 @@ subagent Investigate the failing test
   Root cause: the CI image pins an older openssl, so the fixture's certificate...
 ```
 
-`cwd` shows only when the child ran somewhere other than the parent session's
-directory. While the run is in flight the row shows the metadata list alone, tinted
-as pending. `ctrl+o` expands the full prompt and the full output.
+`cwd` shows only when it differs from the parent's. `ctrl+o` expands the prompt and
+the output.
 
 ## Sessions
 
-Each child persists a real session, named after the call's `description`, so you can
-open what a subagent actually did:
-
-```bash
-pi --session 019fd2ff-cca1-7a91-866c-7eedf6bc222c
-```
-
-pi resolves the id from anywhere and offers to fork the run into the current
-directory; pass the session file path instead to open it in place. Either way it is a
-snapshot at open time — pi has no live-follow of a session file.
-
-Child sessions live in `~/.pi/agent/sessions/subagents/`, beside pi's per-project
-session directories rather than inside one. They therefore never show up in `pi -c`
-or `pi -r` for a project — otherwise `pi -c` would resume the most recent _subagent_
-run — while staying resolvable by id and listed in the all-projects picker. Nothing
-prunes them.
+Children persist a session named after the call's `description`, so
+`pi --session <id>` opens what a subagent did. They live in
+`~/.pi/agent/sessions/subagents/`, outside any project directory, so they never
+appear in `pi -c` or `pi -r` — pi offers to fork them into the current directory
+instead. Nothing prunes them.

--- a/plugins/subagent/README.md
+++ b/plugins/subagent/README.md
@@ -4,8 +4,8 @@ A minimal subagent tool for [pi-agent](https://github.com/earendil-works/pi):
 delegate a task to a fresh, headless pi instance with an isolated context window.
 
 No agent presets, no orchestration modes — just a `subagent` tool that spawns another
-instance of the running pi harness (`pi --mode json -p --no-session`) and returns its
-final response. Child processes inherit the parent environment with
+instance of the running pi harness (`pi --mode json -p`) and returns its final
+response. Child processes inherit the parent environment with
 `PI_CACHE_RETENTION=short`, so they keep pi's standard provider cache retention
 instead of inheriting a process-wide or OAuth-plugin extended setting.
 
@@ -35,3 +35,47 @@ pi -e ./plugins/subagent
 | `prompt`      | yes      | The task for the agent to perform                                      |
 | `model`       | no       | Model override for this agent (passed to `pi --model`)                 |
 | `cwd`         | no       | Working directory for the agent process (defaults to the parent's cwd) |
+
+## The tool row
+
+The row does not stream. It paints twice — once when the child reports its session
+id, once when the run ends — so subagents that scroll out of view never drag the
+viewport around:
+
+```text
+subagent Investigate the failing test
+  Investigate why the auth integration test fails on CI but passes locally. Look
+  at the test setup, the fixtures it loads and any environment differences
+  between the CI container and a dev machine.
+  ... (4 more lines, ctrl+o to expand)
+
+  cwd      /some/other/path
+  model    anthropic/claude-sonnet-4-5:high
+  session  019fd2ff-cca1-7a91-866c-7eedf6bc222c
+
+  ✓ 4 turns 12 tools ↑12k ↓3.0k $0.0412 1m22s
+  Root cause: the CI image pins an older openssl, so the fixture's certificate...
+```
+
+`cwd` shows only when the child ran somewhere other than the parent session's
+directory. While the run is in flight the row shows the metadata list alone, tinted
+as pending. `ctrl+o` expands the full prompt and the full output.
+
+## Sessions
+
+Each child persists a real session, named after the call's `description`, so you can
+open what a subagent actually did:
+
+```bash
+pi --session 019fd2ff-cca1-7a91-866c-7eedf6bc222c
+```
+
+pi resolves the id from anywhere and offers to fork the run into the current
+directory; pass the session file path instead to open it in place. Either way it is a
+snapshot at open time — pi has no live-follow of a session file.
+
+Child sessions live in `~/.pi/agent/sessions/subagents/`, beside pi's per-project
+session directories rather than inside one. They therefore never show up in `pi -c`
+or `pi -r` for a project — otherwise `pi -c` would resume the most recent _subagent_
+run — while staying resolvable by id and listed in the all-projects picker. Nothing
+prunes them.

--- a/plugins/subagent/src/index.ts
+++ b/plugins/subagent/src/index.ts
@@ -19,8 +19,6 @@ import {
 } from './utils'
 
 const PROMPT_PREVIEW_LINES = 3
-
-/** Column the metadata values line up at. */
 const METADATA_LABEL_WIDTH = 9
 
 const subagentSchema = Type.Object({
@@ -46,9 +44,7 @@ const subagentSchema = Type.Object({
 export type SubagentInput = Static<typeof subagentSchema>
 
 interface SubagentDetails extends SubagentResult {
-  /** Working directory the child ran in. */
   cwd?: string | undefined
-  /** Model pattern the child was started with, resolved at call time. */
   model?: string | undefined
   /** Set on the final result when the run failed. */
   failed?: boolean | undefined
@@ -115,9 +111,8 @@ export default function subagent(pi: ExtensionAPI) {
         model,
         cwd,
         tools,
-        // The only live update: every further redraw of a row that has scrolled
-        // out of view drags pi's viewport around, so the session id is what the
-        // run reports instead of streaming progress.
+        // The only live update: each one repaints pi's scrollback once the row
+        // has scrolled out of view.
         onSession: (sessionId) => {
           onUpdate?.({
             content: [{ type: 'text', text: '' }],
@@ -191,29 +186,27 @@ export default function subagent(pi: ExtensionAPI) {
       }
     },
     renderResult({ details }, { expanded, isPartial }, theme, context) {
-      const metadata: string[] = []
-      const addMetadata = (label: string, value: string) => {
-        metadata.push(
-          theme.fg('dim', label.padEnd(METADATA_LABEL_WIDTH)) +
-            theme.fg('muted', value),
-        )
-      }
+      const metadata: Array<[string, string]> = []
       if (details.cwd !== undefined && details.cwd !== context.cwd) {
-        addMetadata('cwd', details.cwd)
+        metadata.push(['cwd', details.cwd])
       }
       if (details.model !== undefined) {
-        addMetadata('model', details.model)
+        metadata.push(['model', details.model])
       }
       if (details.sessionId !== undefined) {
-        // Never truncated: session ids are uuidv7, so a prefix collides across a
-        // parallel batch of subagents and `pi --session` resolves an arbitrary one.
-        addMetadata('session', details.sessionId)
+        // Never a prefix: uuidv7 ids share their leading digits across a batch.
+        metadata.push(['session', details.sessionId])
       }
 
-      const metadataBlock = metadata.join('\n')
+      const metadataBlock = metadata
+        .map(
+          ([label, value]) =>
+            theme.fg('dim', label.padEnd(METADATA_LABEL_WIDTH)) +
+            theme.fg('muted', value),
+        )
+        .join('\n')
 
-      // While running the metadata is the whole row; the pending background
-      // tint says it is still going.
+      // No status line while running: the pending background tint is the indicator.
       if (isPartial) {
         return new Text(metadataBlock ? `\n${metadataBlock}` : '', 0, 0)
       }

--- a/plugins/subagent/src/index.ts
+++ b/plugins/subagent/src/index.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { Text } from '@earendil-works/pi-tui'
 import * as NodeServices from '@effect/platform-node/NodeServices'
-import { renderExpandableText, TextPreview } from '@pi-plugins/shared'
+import { ExpandableText, TextPreview } from '@pi-plugins/shared'
 import { Effect } from 'effect'
 import { Type, type Static } from 'typebox'
 import {
@@ -18,7 +18,10 @@ import {
   subagentSessionDir,
 } from './utils'
 
+// Wrapped terminal rows, not source lines, so a row's height is bounded whatever
+// the prompt and the output happen to be shaped like.
 const PROMPT_PREVIEW_LINES = 3
+const OUTPUT_PREVIEW_LINES = 5
 const METADATA_LABEL_WIDTH = 9
 
 const subagentSchema = Type.Object({
@@ -229,20 +232,15 @@ export default function subagent(pi: ExtensionAPI) {
         header += `\n${theme.fg('error', `Error: ${details.errorMessage}`)}`
       }
 
-      // Keep the full output in details for explicit expansion, but bound the
-      // default rendering to pi's standard tool-output limits.
-      const displayContent = expanded ? content : capToolOutput(content)
-
-      const text = new Text('', 0, 0)
-      text.setText(
-        renderExpandableText({
-          header,
-          content: displayContent,
-          expanded,
-          theme,
-        }),
-      )
-      return text
+      return new ExpandableText({
+        header,
+        // Keep the full output in details for explicit expansion, but bound what
+        // the collapsed row has to wrap to pi's standard tool-output limits.
+        content: expanded ? content : capToolOutput(content),
+        maxLines: OUTPUT_PREVIEW_LINES,
+        expanded,
+        theme,
+      })
     },
   })
 }

--- a/plugins/subagent/src/index.ts
+++ b/plugins/subagent/src/index.ts
@@ -2,19 +2,26 @@ import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { Text } from '@earendil-works/pi-tui'
 import * as NodeServices from '@effect/platform-node/NodeServices'
-import { previewLines, renderExpandableText } from '@pi-plugins/shared'
+import { renderExpandableText, TextPreview } from '@pi-plugins/shared'
 import { Effect } from 'effect'
 import { Type, type Static } from 'typebox'
 import {
-  emptySnapshot,
+  emptyResult,
   runSubagent,
-  type SubagentSnapshot,
+  type SubagentResult,
   type SubagentUsage,
 } from './runner'
-import { capToolOutput, formatUsage, modelPattern } from './utils'
+import {
+  capToolOutput,
+  formatStats,
+  modelPattern,
+  subagentSessionDir,
+} from './utils'
 
-const PROMPT_PREVIEW_LINES = 2
-const PROMPT_PREVIEW_WIDTH = 80
+const PROMPT_PREVIEW_LINES = 3
+
+/** Column the metadata values line up at. */
+const METADATA_LABEL_WIDTH = 9
 
 const subagentSchema = Type.Object({
   description: Type.String({
@@ -38,7 +45,11 @@ const subagentSchema = Type.Object({
 
 export type SubagentInput = Static<typeof subagentSchema>
 
-interface SubagentDetails extends SubagentSnapshot {
+interface SubagentDetails extends SubagentResult {
+  /** Working directory the child ran in. */
+  cwd?: string | undefined
+  /** Model pattern the child was started with, resolved at call time. */
+  model?: string | undefined
   /** Set on the final result when the run failed. */
   failed?: boolean | undefined
   errorMessage?: string | undefined
@@ -87,6 +98,11 @@ export default function subagent(pi: ExtensionAPI) {
           ? modelPattern(ctx.model, pi.getThinkingLevel())
           : undefined)
 
+      // Resolve relative cwd against the parent session's cwd, not the process
+      // cwd (they can differ for resumed/cross-project sessions).
+      const cwd =
+        params.cwd !== undefined ? path.resolve(ctx.cwd, params.cwd) : ctx.cwd
+
       // Inherit the parent's active tool set (minus subagent itself) so a
       // restricted parent (e.g. `pi --tools read`) cannot be escaped by
       // delegating to a child with default tools.
@@ -94,34 +110,32 @@ export default function subagent(pi: ExtensionAPI) {
 
       const program = runSubagent({
         prompt: params.prompt,
+        sessionDir: subagentSessionDir(),
+        name: params.description,
         model,
-        // Resolve relative cwd against the parent session's cwd, not the
-        // process cwd (they can differ for resumed/cross-project sessions).
-        cwd: params.cwd !== undefined ? path.resolve(ctx.cwd, params.cwd) : ctx.cwd,
+        cwd,
         tools,
-        onUpdate: (snapshot) => {
+        // The only live update: every further redraw of a row that has scrolled
+        // out of view drags pi's viewport around, so the session id is what the
+        // run reports instead of streaming progress.
+        onSession: (sessionId) => {
           onUpdate?.({
-            content: [
-              {
-                type: 'text',
-                text: snapshot.output || snapshot.thinking || '(running...)',
-              },
-            ],
-            details: snapshot,
+            content: [{ type: 'text', text: '' }],
+            details: { ...emptyResult, sessionId, model, cwd },
           })
         },
       }).pipe(
-        Effect.map((snapshot) => ({
+        Effect.map((result) => ({
           content: [
             {
               type: 'text' as const,
-              text: snapshot.output ? capToolOutput(snapshot.output) : '(no output)',
+              text: result.output ? capToolOutput(result.output) : '(no output)',
             },
           ],
-          details: snapshot as SubagentDetails,
+          details: { ...result, model, cwd },
         })),
         Effect.catch((error) => {
-          const snapshot = 'snapshot' in error ? error.snapshot : emptySnapshot
+          const result = 'result' in error ? error.result : emptyResult
           const label = error._tag === 'SubagentStopError' ? error.reason : 'failed'
           const reason =
             error._tag === 'PlatformError'
@@ -135,7 +149,9 @@ export default function subagent(pi: ExtensionAPI) {
               },
             ],
             details: {
-              ...snapshot,
+              ...result,
+              model,
+              cwd,
               failed: true,
               errorMessage: reason,
               stderr: 'stderr' in error ? error.stderr : undefined,
@@ -149,59 +165,72 @@ export default function subagent(pi: ExtensionAPI) {
 
       return await Effect.runPromise(program, { signal })
     },
-    renderCall(args, theme) {
-      let text =
+    renderCall(args, theme, { expanded }) {
+      const title = new Text(
         theme.fg('toolTitle', theme.bold('subagent ')) +
-        theme.fg('accent', args.description ?? '...')
-
-      const extras: string[] = []
-      if (args.model !== undefined) {
-        extras.push(args.model)
-      }
-      if (args.cwd !== undefined) {
-        extras.push(args.cwd)
-      }
-      if (extras.length > 0) {
-        text += theme.fg('muted', ` (${extras.join(', ')})`)
+          theme.fg('accent', args.description ?? '...'),
+        0,
+        0,
+      )
+      if (args.prompt === undefined) {
+        return title
       }
 
-      if (args.prompt !== undefined) {
-        for (const line of previewLines(
-          args.prompt,
-          PROMPT_PREVIEW_LINES,
-          PROMPT_PREVIEW_WIDTH,
-        )) {
-          text += `\n${theme.fg('dim', line)}`
-        }
+      const preview = new TextPreview({
+        text: args.prompt,
+        maxLines: PROMPT_PREVIEW_LINES,
+        expanded,
+        theme,
+      })
+      return {
+        render: (width) => [...title.render(width), ...preview.render(width)],
+        invalidate: () => {
+          title.invalidate()
+          preview.invalidate()
+        },
       }
-
-      return new Text(text, 0, 0)
     },
-    renderResult({ details }, { expanded, isPartial }, theme) {
-      const running = isPartial
-      const failed = details.failed === true
-
-      const icon = running
-        ? theme.fg('accent', '●')
-        : failed
-          ? theme.fg('error', '✗')
-          : theme.fg('success', '✓')
-
-      const usage = formatUsage(details.usage, details.model, details.toolCalls)
-      let header = icon
-      if (usage) {
-        header += ` ${theme.fg('muted', usage)}`
-      } else if (running) {
-        header += ` ${theme.fg('muted', 'starting...')}`
+    renderResult({ details }, { expanded, isPartial }, theme, context) {
+      const metadata: string[] = []
+      const addMetadata = (label: string, value: string) => {
+        metadata.push(
+          theme.fg('dim', label.padEnd(METADATA_LABEL_WIDTH)) +
+            theme.fg('muted', value),
+        )
       }
-      // Models that emit no interim text (e.g. OpenAI/codex) still stream
-      // thinking summaries; surface those as live status while running.
+      if (details.cwd !== undefined && details.cwd !== context.cwd) {
+        addMetadata('cwd', details.cwd)
+      }
+      if (details.model !== undefined) {
+        addMetadata('model', details.model)
+      }
+      if (details.sessionId !== undefined) {
+        // Never truncated: session ids are uuidv7, so a prefix collides across a
+        // parallel batch of subagents and `pi --session` resolves an arbitrary one.
+        addMetadata('session', details.sessionId)
+      }
+
+      const metadataBlock = metadata.join('\n')
+
+      // While running the metadata is the whole row; the pending background
+      // tint says it is still going.
+      if (isPartial) {
+        return new Text(metadataBlock ? `\n${metadataBlock}` : '', 0, 0)
+      }
+
+      const failed = details.failed === true
+      const stats = formatStats(details)
+      let status = failed ? theme.fg('error', '✗') : theme.fg('success', '✓')
+      if (stats) {
+        status += ` ${theme.fg('muted', stats)}`
+      }
+
       const content =
         details.output ||
-        (running ? details.thinking : '') ||
         (failed ? (details.stderr?.trim() ?? '') : '') ||
-        (running ? '(running...)' : '(no output)')
+        '(no output)'
 
+      let header = metadataBlock ? `\n${metadataBlock}\n\n${status}` : `\n${status}`
       // Skip the error line when it would repeat the rendered content.
       if (failed && details.errorMessage && details.errorMessage !== content) {
         header += `\n${theme.fg('error', `Error: ${details.errorMessage}`)}`

--- a/plugins/subagent/src/runner.ts
+++ b/plugins/subagent/src/runner.ts
@@ -26,9 +26,7 @@ export interface SubagentResult {
   output: string
   toolCalls: number
   usage: SubagentUsage
-  /** Child's pi session id, from the `session` header of its event stream. */
   sessionId?: string | undefined
-  /** Wall-clock duration of the child process. */
   durationMs?: number | undefined
 }
 
@@ -55,7 +53,6 @@ export class SubagentStopError extends Data.TaggedError('SubagentStopError')<{
   /** Error detail reported by the child, if any. */
   readonly errorMessage?: string | undefined
   readonly stderr: string
-  /** Progress made up to the failure. */
   readonly result: SubagentResult
 }> {
   override readonly message: string =
@@ -69,7 +66,6 @@ export class SubagentStopError extends Data.TaggedError('SubagentStopError')<{
 export class SubagentExitError extends Data.TaggedError('SubagentExitError')<{
   readonly exitCode: number
   readonly stderr: string
-  /** Progress made up to the failure. */
   readonly result: SubagentResult
 }> {
   override readonly message: string =
@@ -87,7 +83,6 @@ export class SubagentNoOutputError extends Data.TaggedError(
   'SubagentNoOutputError',
 )<{
   readonly stderr: string
-  /** Progress made up to the failure. */
   readonly result: SubagentResult
 }> {
   override readonly message: string =
@@ -209,20 +204,16 @@ function resolvePiInvocation(args: ReadonlyArray<string>): {
 
 /**
  * Runs one headless pi instance for the given prompt and folds its JSONL
- * event stream into a `SubagentResult`.
+ * event stream into a `SubagentResult`. `onSession` fires once, when the child
+ * reports the id of the session it persists to.
  */
 export function runSubagent(options: {
   prompt: string
   sessionDir: string
-  /** Display name for the child's session. */
   name?: string | undefined
-  /** Optional model override, passed to `pi --model`. */
   model?: string | undefined
-  /** Working directory for the spawned pi process. */
   cwd?: string | undefined
-  /** Tool allowlist for the child. */
   tools?: ReadonlyArray<string> | undefined
-  /** Called once, when the child reports its session id. */
   onSession?: ((sessionId: string) => void) | undefined
 }): Effect.Effect<
   SubagentResult,

--- a/plugins/subagent/src/runner.ts
+++ b/plugins/subagent/src/runner.ts
@@ -21,17 +21,14 @@ export interface SubagentUsage {
   contextTokens: number
 }
 
-/**
- * What a subagent run produced: the child's final output plus what it took to
- * get there. Errors carry the partial result of the work done before failing.
- */
+/** What a run produced; errors carry the partial result of the work done so far. */
 export interface SubagentResult {
   output: string
   toolCalls: number
   usage: SubagentUsage
-  /** Child's pi session id, read from the `session` header of its event stream. */
+  /** Child's pi session id, from the `session` header of its event stream. */
   sessionId?: string | undefined
-  /** Wall-clock duration of the child process, in milliseconds. */
+  /** Wall-clock duration of the child process. */
   durationMs?: number | undefined
 }
 
@@ -98,13 +95,12 @@ export class SubagentNoOutputError extends Data.TaggedError(
     (this.stderr.trim() ? `\nstderr: ${this.stderr.trim()}` : '')
 }
 
-/** The session header pi prints as the first line of a `--mode json` stream. */
+/** The header pi prints as the first line of a `--mode json` stream. */
 const SessionHeader = Schema.Struct({
   type: Schema.Literal('session'),
   id: Schema.String,
 })
 
-/** A completed assistant message. */
 const AssistantMessageEnd = Schema.Struct({
   type: Schema.Literal('message_end'),
   message: Schema.Struct({
@@ -217,7 +213,6 @@ function resolvePiInvocation(args: ReadonlyArray<string>): {
  */
 export function runSubagent(options: {
   prompt: string
-  /** Directory the child persists its session into. */
   sessionDir: string
   /** Display name for the child's session. */
   name?: string | undefined
@@ -227,7 +222,7 @@ export function runSubagent(options: {
   cwd?: string | undefined
   /** Tool allowlist for the child. */
   tools?: ReadonlyArray<string> | undefined
-  /** Called once, when the child reports the id of the session it writes to. */
+  /** Called once, when the child reports its session id. */
   onSession?: ((sessionId: string) => void) | undefined
 }): Effect.Effect<
   SubagentResult,
@@ -247,8 +242,7 @@ export function runSubagent(options: {
         '--exclude-tools',
         'subagent',
       ]
-      // pi rejects an empty --name, and an unnamed run is still identifiable
-      // by its prompt in the session picker.
+      // pi exits on an empty --name.
       const name = options.name?.trim()
       if (name) {
         args.push('--name', name)
@@ -305,8 +299,7 @@ export function runSubagent(options: {
           (previous, event) =>
             Effect.sync(() => {
               if (event.type === 'session') {
-                // The first header wins: reporting a later one would cost the
-                // row the extra render this whole design avoids.
+                // A second header would cost the caller an extra render.
                 if (previous.result.sessionId !== undefined) {
                   return previous
                 }

--- a/plugins/subagent/src/runner.ts
+++ b/plugins/subagent/src/runner.ts
@@ -22,25 +22,21 @@ export interface SubagentUsage {
 }
 
 /**
- * Progress of a subagent run, emitted after every completed message and
- * returned as the final value of a successful run.
+ * What a subagent run produced: the child's final output plus what it took to
+ * get there. Errors carry the partial result of the work done before failing.
  */
-export interface SubagentSnapshot {
+export interface SubagentResult {
   output: string
-  /**
-   * Latest thinking/reasoning summary. Used as a live status fallback for
-   * models that emit no interim text between tool calls (e.g. OpenAI/codex
-   * models, which only produce a text block on their final message).
-   */
-  thinking: string
   toolCalls: number
   usage: SubagentUsage
-  model?: string | undefined
+  /** Child's pi session id, read from the `session` header of its event stream. */
+  sessionId?: string | undefined
+  /** Wall-clock duration of the child process, in milliseconds. */
+  durationMs?: number | undefined
 }
 
-export const emptySnapshot: SubagentSnapshot = {
+export const emptyResult: SubagentResult = {
   output: '',
-  thinking: '',
   toolCalls: 0,
   usage: {
     turns: 0,
@@ -63,12 +59,12 @@ export class SubagentStopError extends Data.TaggedError('SubagentStopError')<{
   readonly errorMessage?: string | undefined
   readonly stderr: string
   /** Progress made up to the failure. */
-  readonly snapshot: SubagentSnapshot
+  readonly result: SubagentResult
 }> {
   override readonly message: string =
     this.errorMessage ||
     this.stderr.trim() ||
-    this.snapshot.output ||
+    this.result.output ||
     `run stopped (${this.reason})`
 }
 
@@ -77,11 +73,11 @@ export class SubagentExitError extends Data.TaggedError('SubagentExitError')<{
   readonly exitCode: number
   readonly stderr: string
   /** Progress made up to the failure. */
-  readonly snapshot: SubagentSnapshot
+  readonly result: SubagentResult
 }> {
   override readonly message: string =
     this.stderr.trim() ||
-    this.snapshot.output ||
+    this.result.output ||
     `pi exited with code ${this.exitCode}`
 }
 
@@ -94,98 +90,97 @@ export class SubagentNoOutputError extends Data.TaggedError(
   'SubagentNoOutputError',
 )<{
   readonly stderr: string
+  /** Progress made up to the failure. */
+  readonly result: SubagentResult
 }> {
   override readonly message: string =
     'Subagent produced no assistant messages (unexpected or empty JSON event stream)' +
     (this.stderr.trim() ? `\nstderr: ${this.stderr.trim()}` : '')
 }
 
-/**
- * The `--mode json` event lines we care about (see pi docs/json.md): completed
- * assistant messages.
- */
-const AssistantMessageEnd = Schema.fromJsonString(
-  Schema.Struct({
-    type: Schema.Literal('message_end'),
-    message: Schema.Struct({
-      role: Schema.Literal('assistant'),
-      content: Schema.Array(
-        Schema.Struct({
-          type: Schema.String,
-          text: Schema.optional(Schema.String),
-          thinking: Schema.optional(Schema.String),
-        }),
-      ),
-      usage: Schema.optional(
-        Schema.Struct({
-          input: Schema.optional(Schema.Number),
-          output: Schema.optional(Schema.Number),
-          cacheRead: Schema.optional(Schema.Number),
-          cacheWrite: Schema.optional(Schema.Number),
-          totalTokens: Schema.optional(Schema.Number),
-          cost: Schema.optional(
-            Schema.Struct({ total: Schema.optional(Schema.Number) }),
-          ),
-        }),
-      ),
-      model: Schema.optional(Schema.String),
-      stopReason: Schema.optional(Schema.String),
-      errorMessage: Schema.optional(Schema.String),
-    }),
+/** The session header pi prints as the first line of a `--mode json` stream. */
+const SessionHeader = Schema.Struct({
+  type: Schema.Literal('session'),
+  id: Schema.String,
+})
+
+/** A completed assistant message. */
+const AssistantMessageEnd = Schema.Struct({
+  type: Schema.Literal('message_end'),
+  message: Schema.Struct({
+    role: Schema.Literal('assistant'),
+    content: Schema.Array(
+      Schema.Struct({
+        type: Schema.String,
+        text: Schema.optional(Schema.String),
+      }),
+    ),
+    usage: Schema.optional(
+      Schema.Struct({
+        input: Schema.optional(Schema.Number),
+        output: Schema.optional(Schema.Number),
+        cacheRead: Schema.optional(Schema.Number),
+        cacheWrite: Schema.optional(Schema.Number),
+        totalTokens: Schema.optional(Schema.Number),
+        cost: Schema.optional(
+          Schema.Struct({ total: Schema.optional(Schema.Number) }),
+        ),
+      }),
+    ),
+    stopReason: Schema.optional(Schema.String),
+    errorMessage: Schema.optional(Schema.String),
   }),
+})
+
+/**
+ * The `--mode json` event lines we care about (see pi docs/json.md): the
+ * session header and completed assistant messages.
+ */
+const SubagentEvent = Schema.fromJsonString(
+  Schema.Union([SessionHeader, AssistantMessageEnd]),
 )
 
 type AssistantMessage = (typeof AssistantMessageEnd)['Type']['message']
 
-/** Fold state: the public snapshot plus the child's last reported stop info. */
+/** Fold state: the public result plus the child's last reported stop info. */
 interface RunState {
-  snapshot: SubagentSnapshot
+  result: SubagentResult
   stopReason?: string | undefined
   errorMessage?: string | undefined
 }
 
-const initialState: RunState = { snapshot: emptySnapshot }
+const initialState: RunState = { result: emptyResult }
 
 /** Folds one completed assistant message into the run state. */
 function foldMessage(state: RunState, message: AssistantMessage): RunState {
-  const { snapshot } = state
-  let toolCalls = snapshot.toolCalls
+  const { result } = state
+  let toolCalls = result.toolCalls
   const texts: string[] = []
-  const thinkingTexts: string[] = []
   for (const part of message.content) {
     if (part.type === 'text' && part.text !== undefined) {
       texts.push(part.text)
-    } else if (part.type === 'thinking' && part.thinking !== undefined) {
-      thinkingTexts.push(part.thinking)
     } else if (part.type === 'toolCall') {
       toolCalls += 1
     }
   }
   const text = texts.join('\n\n').trim()
-  const output = text.length > 0 ? text : snapshot.output
-  // Strip empty HTML-comment separators that codex reasoning summaries embed.
-  const thinkingText = thinkingTexts
-    .join('\n\n')
-    .replace(/<!--\s*-->/g, '')
-    .trim()
-  const thinking = thinkingText.length > 0 ? thinkingText : snapshot.thinking
+  const output = text.length > 0 ? text : result.output
 
   const usage = message.usage
   return {
-    snapshot: {
+    result: {
+      ...result,
       output,
-      thinking,
       toolCalls,
       usage: {
-        turns: snapshot.usage.turns + 1,
-        input: snapshot.usage.input + (usage?.input ?? 0),
-        output: snapshot.usage.output + (usage?.output ?? 0),
-        cacheRead: snapshot.usage.cacheRead + (usage?.cacheRead ?? 0),
-        cacheWrite: snapshot.usage.cacheWrite + (usage?.cacheWrite ?? 0),
-        cost: snapshot.usage.cost + (usage?.cost?.total ?? 0),
-        contextTokens: usage?.totalTokens ?? snapshot.usage.contextTokens,
+        turns: result.usage.turns + 1,
+        input: result.usage.input + (usage?.input ?? 0),
+        output: result.usage.output + (usage?.output ?? 0),
+        cacheRead: result.usage.cacheRead + (usage?.cacheRead ?? 0),
+        cacheWrite: result.usage.cacheWrite + (usage?.cacheWrite ?? 0),
+        cost: result.usage.cost + (usage?.cost?.total ?? 0),
+        contextTokens: usage?.totalTokens ?? result.usage.contextTokens,
       },
-      model: message.model ?? snapshot.model,
     },
     stopReason: message.stopReason ?? state.stopReason,
     errorMessage: message.errorMessage ?? state.errorMessage,
@@ -218,20 +213,24 @@ function resolvePiInvocation(args: ReadonlyArray<string>): {
 
 /**
  * Runs one headless pi instance for the given prompt and folds its JSONL
- * event stream into a `SubagentSnapshot`.
+ * event stream into a `SubagentResult`.
  */
 export function runSubagent(options: {
   prompt: string
+  /** Directory the child persists its session into. */
+  sessionDir: string
+  /** Display name for the child's session. */
+  name?: string | undefined
   /** Optional model override, passed to `pi --model`. */
   model?: string | undefined
   /** Working directory for the spawned pi process. */
   cwd?: string | undefined
   /** Tool allowlist for the child. */
   tools?: ReadonlyArray<string> | undefined
-  /** Called with a fresh snapshot whenever the subagent completes a message. */
-  onUpdate?: ((snapshot: SubagentSnapshot) => void) | undefined
+  /** Called once, when the child reports the id of the session it writes to. */
+  onSession?: ((sessionId: string) => void) | undefined
 }): Effect.Effect<
-  SubagentSnapshot,
+  SubagentResult,
   SubagentStopError | SubagentExitError | SubagentNoOutputError | PlatformError,
   ChildProcessSpawner.ChildProcessSpawner
 > {
@@ -243,10 +242,17 @@ export function runSubagent(options: {
         '--mode',
         'json',
         '-p',
-        '--no-session',
+        '--session-dir',
+        options.sessionDir,
         '--exclude-tools',
         'subagent',
       ]
+      // pi rejects an empty --name, and an unnamed run is still identifiable
+      // by its prompt in the session picker.
+      const name = options.name?.trim()
+      if (name) {
+        args.push('--name', name)
+      }
       // Inherit the parent's active tool set so a restricted parent
       // (e.g. `--tools read`) cannot be escaped through the child.
       if (options.tools !== undefined) {
@@ -260,6 +266,7 @@ export function runSubagent(options: {
         args.push('--model', options.model)
       }
       const invocation = resolvePiInvocation(args)
+      const startedAt = Date.now()
       const handle = yield* ChildProcess.make(
         invocation.command,
         [...invocation.args],
@@ -273,8 +280,6 @@ export function runSubagent(options: {
           forceKillAfter: FORCE_KILL_AFTER,
         },
       )
-
-      options.onUpdate?.(emptySnapshot)
 
       const stderrFiber = yield* Effect.forkScoped(
         handle.stderr.pipe(
@@ -293,41 +298,49 @@ export function runSubagent(options: {
         Stream.decodeText,
         Stream.splitLines,
         Stream.filterMap(
-          Filter.fromPredicateOption(
-            Schema.decodeUnknownOption(AssistantMessageEnd),
-          ),
+          Filter.fromPredicateOption(Schema.decodeUnknownOption(SubagentEvent)),
         ),
         Stream.runFoldEffect(
           () => initialState,
           (previous, event) =>
             Effect.sync(() => {
-              const next = foldMessage(previous, event.message)
-              options.onUpdate?.(next.snapshot)
-              return next
+              if (event.type === 'session') {
+                // The first header wins: reporting a later one would cost the
+                // row the extra render this whole design avoids.
+                if (previous.result.sessionId !== undefined) {
+                  return previous
+                }
+                options.onSession?.(event.id)
+                return {
+                  ...previous,
+                  result: { ...previous.result, sessionId: event.id },
+                }
+              }
+              return foldMessage(previous, event.message)
             }),
         ),
       )
 
       const exitCode = Number(yield* handle.exitCode)
       const stderr = yield* Fiber.join(stderrFiber)
-      const { snapshot } = state
+      const result = { ...state.result, durationMs: Date.now() - startedAt }
 
       if (state.stopReason === 'error' || state.stopReason === 'aborted') {
         return yield* new SubagentStopError({
           reason: state.stopReason,
           errorMessage: state.errorMessage,
           stderr,
-          snapshot,
+          result,
         })
       }
       if (exitCode !== 0) {
-        return yield* new SubagentExitError({ exitCode, stderr, snapshot })
+        return yield* new SubagentExitError({ exitCode, stderr, result })
       }
-      if (snapshot.usage.turns === 0) {
-        return yield* new SubagentNoOutputError({ stderr })
+      if (result.usage.turns === 0) {
+        return yield* new SubagentNoOutputError({ stderr, result })
       }
 
-      return snapshot
+      return result
     }),
   )
 }

--- a/plugins/subagent/src/utils.ts
+++ b/plugins/subagent/src/utils.ts
@@ -1,6 +1,19 @@
-import { truncateHead } from '@earendil-works/pi-coding-agent'
+import * as path from 'node:path'
+import { getAgentDir, truncateHead } from '@earendil-works/pi-coding-agent'
 import { formatTruncationNotice } from '@pi-plugins/shared'
-import type { SubagentUsage } from './runner'
+import type { SubagentResult } from './runner'
+
+/**
+ * Sits beside pi's per-project session directories, which are always named
+ * `--<encoded cwd>--`, so child sessions stay out of `pi -c` / `pi -r` for any
+ * project while remaining resolvable by id from anywhere.
+ */
+const SESSION_DIR_NAME = 'subagents'
+
+/** Directory the child pi processes persist their sessions into. */
+export function subagentSessionDir(): string {
+  return path.join(getAgentDir(), 'sessions', SESSION_DIR_NAME)
+}
 
 /** Caps text to pi's standard tool-output limits, appending a notice when truncated. */
 export function capToolOutput(text: string): string {
@@ -24,17 +37,34 @@ export function formatTokens(count: number): string {
   return `${(count / 1000000).toFixed(1)}M`
 }
 
-/** Formats usage stats as a compact one-line summary (turns, tools, tokens, cost, model). */
-export function formatUsage(
-  usage: SubagentUsage,
-  model?: string,
-  toolCalls?: number,
-): string {
+function pad(value: number): string {
+  return value.toString().padStart(2, '0')
+}
+
+/** Formats a wall-clock duration compactly (e.g. `9s`, `1m22s`, `2h07m30s`). */
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000)
+  const seconds = totalSeconds % 60
+  const minutes = Math.floor(totalSeconds / 60) % 60
+  const hours = Math.floor(totalSeconds / 3600)
+
+  if (hours > 0) {
+    return `${hours}h${pad(minutes)}m${pad(seconds)}s`
+  }
+  if (minutes > 0) {
+    return `${minutes}m${pad(seconds)}s`
+  }
+  return `${seconds}s`
+}
+
+/** Formats a finished run as one line: turns, tools, tokens, cost, duration. */
+export function formatStats(result: SubagentResult): string {
+  const { usage, toolCalls } = result
   const parts: string[] = []
   if (usage.turns > 0) {
     parts.push(`${usage.turns} turn${usage.turns > 1 ? 's' : ''}`)
   }
-  if (toolCalls !== undefined && toolCalls > 0) {
+  if (toolCalls > 0) {
     parts.push(`${toolCalls} tool${toolCalls > 1 ? 's' : ''}`)
   }
   if (usage.input > 0) {
@@ -52,8 +82,8 @@ export function formatUsage(
   if (usage.cost > 0) {
     parts.push(`$${usage.cost.toFixed(4)}`)
   }
-  if (model !== undefined) {
-    parts.push(model)
+  if (result.durationMs !== undefined) {
+    parts.push(formatDuration(result.durationMs))
   }
   return parts.join(' ')
 }

--- a/plugins/subagent/src/utils.ts
+++ b/plugins/subagent/src/utils.ts
@@ -4,15 +4,11 @@ import { formatTruncationNotice } from '@pi-plugins/shared'
 import type { SubagentResult } from './runner'
 
 /**
- * Sits beside pi's per-project session directories, which are always named
- * `--<encoded cwd>--`, so child sessions stay out of `pi -c` / `pi -r` for any
- * project while remaining resolvable by id from anywhere.
+ * Beside pi's per-project session directories, which are always `--<cwd>--`, so
+ * child sessions stay out of `pi -c` / `pi -r` but resolve by id from anywhere.
  */
-const SESSION_DIR_NAME = 'subagents'
-
-/** Directory the child pi processes persist their sessions into. */
 export function subagentSessionDir(): string {
-  return path.join(getAgentDir(), 'sessions', SESSION_DIR_NAME)
+  return path.join(getAgentDir(), 'sessions', 'subagents')
 }
 
 /** Caps text to pi's standard tool-output limits, appending a notice when truncated. */
@@ -37,24 +33,19 @@ export function formatTokens(count: number): string {
   return `${(count / 1000000).toFixed(1)}M`
 }
 
-function pad(value: number): string {
-  return value.toString().padStart(2, '0')
-}
-
-/** Formats a wall-clock duration compactly (e.g. `9s`, `1m22s`, `2h07m30s`). */
+/** Formats a duration compactly (e.g. `9s`, `1m22s`, `2h07m30s`). */
 function formatDuration(ms: number): string {
   const totalSeconds = Math.round(ms / 1000)
-  const seconds = totalSeconds % 60
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`
+  }
+
+  const seconds = `${totalSeconds % 60}`.padStart(2, '0')
   const minutes = Math.floor(totalSeconds / 60) % 60
   const hours = Math.floor(totalSeconds / 3600)
-
-  if (hours > 0) {
-    return `${hours}h${pad(minutes)}m${pad(seconds)}s`
-  }
-  if (minutes > 0) {
-    return `${minutes}m${pad(seconds)}s`
-  }
-  return `${seconds}s`
+  return hours > 0
+    ? `${hours}h${`${minutes}`.padStart(2, '0')}m${seconds}s`
+    : `${minutes}m${seconds}s`
 }
 
 /** Formats a finished run as one line: turns, tools, tokens, cost, duration. */

--- a/plugins/webfetch/src/index.ts
+++ b/plugins/webfetch/src/index.ts
@@ -1,13 +1,14 @@
 import type { ExtensionAPI, TruncationResult } from '@earendil-works/pi-coding-agent'
 import { truncateHead } from '@earendil-works/pi-coding-agent'
-import { Text } from '@earendil-works/pi-tui'
-import { formatTruncationNotice, renderExpandableText } from '@pi-plugins/shared'
+import { ExpandableText, formatTruncationNotice } from '@pi-plugins/shared'
 import { Duration, Effect, Number } from 'effect'
 import { Type, type Static } from 'typebox'
 import { WebFetch, type WebFetchFormat } from './fetch'
 
 const DEFAULT_TIMEOUT_SECONDS = 30
 const MAX_TIMEOUT_SECONDS = 120
+/** Wrapped terminal rows, not source lines: fetched pages are prose, not code. */
+const PREVIEW_LINES = 5
 
 const webFetchSchema = Type.Object({
   url: Type.String({
@@ -85,17 +86,14 @@ export default function webFetch(pi: ExtensionAPI) {
         `(${format})`,
       )}`
 
-      const text = new Text('', 0, 0)
-      text.setText(
-        renderExpandableText({
-          header,
-          content: details.truncation.content,
-          expanded,
-          theme,
-          truncation: details.truncation,
-        }),
-      )
-      return text
+      return new ExpandableText({
+        header,
+        content: details.truncation.content,
+        maxLines: PREVIEW_LINES,
+        expanded,
+        theme,
+        truncation: details.truncation,
+      })
     },
   })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: 0.83.0
         version: 0.83.0(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: 0.83.0
+        version: 0.83.0
       '@pi-plugins/fmt':
         specifier: workspace:*
         version: link:../fmt

--- a/tooling/shared/package.json
+++ b/tooling/shared/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "0.83.0",
+    "@earendil-works/pi-tui": "0.83.0",
     "@pi-plugins/fmt": "workspace:*",
     "@pi-plugins/lint": "workspace:*",
     "@pi-plugins/tsconfig": "workspace:*",
@@ -27,6 +28,7 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
     "effect": "*"
   }
 }

--- a/tooling/shared/src/ui.ts
+++ b/tooling/shared/src/ui.ts
@@ -83,56 +83,60 @@ export function getTextOutput(
     .join('\n')
 }
 
-/**
- * Renders a `header` above its `content`. Trailing blank lines are dropped and
- * the body is capped to a 10-line preview unless `expanded`; when the preview
- * hides lines a "... (N more lines, ... to expand)" hint is appended. A
- * `truncation` notice footer is added when provided.
- */
-export function renderExpandableText({
-  header,
-  content,
-  expanded,
-  theme,
-  truncation,
-}: {
+export interface ExpandableTextOptions {
   header: string
   content: string
+  maxLines: number
   expanded: boolean
   theme: Theme
   truncation?: TruncationResult
-}): string {
-  const lines = content.split('\n')
-  while (lines.length > 0 && lines[lines.length - 1] === '') {
-    lines.pop()
-  }
+}
 
-  const maxLines = expanded ? lines.length : 10
-  const displayLines = lines.slice(0, maxLines)
-  const remaining = lines.length - maxLines
+/**
+ * Renders a `header` above its `content`, previewed at `maxLines` unless
+ * `expanded`. Trailing blank lines are dropped and a `truncation` notice footer
+ * is added when provided.
+ */
+export class ExpandableText implements Component {
+  private readonly parts: Component[]
 
-  let text = header
+  constructor({
+    header,
+    content,
+    maxLines,
+    expanded,
+    theme,
+    truncation,
+  }: ExpandableTextOptions) {
+    const body = content.replace(/\n+$/, '')
+    this.parts = [
+      new Text(header, 0, 0),
+      body
+        ? new TextPreview({
+            text: body,
+            maxLines,
+            expanded,
+            theme,
+            color: 'toolOutput',
+          })
+        : new Text(theme.fg('dim', '(empty response)'), 0, 0),
+    ]
 
-  if (displayLines.length > 0) {
-    text += `\n${displayLines
-      .map((line) => theme.fg('toolOutput', line.replace(/\t/g, '   ')))
-      .join('\n')}`
-  } else {
-    text += `\n${theme.fg('dim', '(empty response)')}`
-  }
-
-  if (remaining > 0) {
-    text += `\n${expandHint(remaining, theme)}`
-  }
-
-  if (truncation) {
-    const notice = formatTruncationNotice(truncation)
+    const notice = truncation ? formatTruncationNotice(truncation) : ''
     if (notice) {
-      text += `\n${theme.fg('warning', notice)}`
+      this.parts.push(new Text(theme.fg('warning', notice), 0, 0))
     }
   }
 
-  return text
+  invalidate(): void {
+    for (const part of this.parts) {
+      part.invalidate()
+    }
+  }
+
+  render(width: number): string[] {
+    return this.parts.flatMap((part) => part.render(width))
+  }
 }
 
 /**

--- a/tooling/shared/src/ui.ts
+++ b/tooling/shared/src/ui.ts
@@ -1,6 +1,7 @@
 import type {
   AgentToolResult,
   Theme,
+  ThemeColor,
   TruncationResult,
 } from '@earendil-works/pi-coding-agent'
 import {
@@ -9,31 +10,71 @@ import {
   formatSize,
   keyHint,
 } from '@earendil-works/pi-coding-agent'
+import type { Component } from '@earendil-works/pi-tui'
+import { Text, truncateToWidth } from '@earendil-works/pi-tui'
+
+/** pi's standard hint for content hidden behind the expand keybinding. */
+function expandHint(hidden: number, theme: Theme): string {
+  return `${theme.fg('muted', `... (${hidden} more lines,`)} ${keyHint(
+    'app.tools.expand',
+    'to expand',
+  )})`
+}
+
+export interface TextPreviewOptions {
+  text: string
+  /** Visual lines to show before the rest is folded behind the expand hint. */
+  maxLines: number
+  expanded: boolean
+  theme: Theme
+  /** Theme color applied to the preview body. */
+  color?: ThemeColor
+}
 
 /**
- * Wraps text into at most `maxLines` preview lines of `width` characters,
- * marking the last line with `...` when the text was cut off.
+ * Previews `text` capped at `maxLines` *visual* lines: lines as the terminal
+ * wraps them at the actual render width, so one long paragraph previews as its
+ * first wrapped lines instead of a wall of text.
  */
-export function previewLines(
-  text: string,
-  maxLines: number,
-  width: number,
-): string[] {
-  const lines: string[] = []
-  outer: for (const line of text.split('\n')) {
-    for (let i = 0; i === 0 || i < line.length; i += width) {
-      lines.push(line.slice(i, i + width))
-      if (lines.length > maxLines) {
-        break outer
-      }
+export class TextPreview implements Component {
+  private readonly body: Text
+  private readonly maxLines: number
+  private readonly expanded: boolean
+  private readonly theme: Theme
+
+  constructor({
+    text,
+    maxLines,
+    expanded,
+    theme,
+    color = 'dim',
+  }: TextPreviewOptions) {
+    // Color per source line; wrapping carries the codes onto each visual line.
+    const styled = text
+      .split('\n')
+      .map((line) => theme.fg(color, line))
+      .join('\n')
+    this.body = new Text(styled, 0, 0)
+    this.maxLines = maxLines
+    this.expanded = expanded
+    this.theme = theme
+  }
+
+  invalidate(): void {
+    this.body.invalidate()
+  }
+
+  render(width: number): string[] {
+    const lines = this.body.render(width)
+    const hidden = lines.length - this.maxLines
+    if (this.expanded || hidden <= 0) {
+      return lines
     }
+    return [
+      ...lines.slice(0, this.maxLines),
+      truncateToWidth(expandHint(hidden, this.theme), width, '...'),
+    ]
   }
-  if (lines.length <= maxLines) {
-    return lines
-  }
-  const preview = lines.slice(0, maxLines)
-  preview[maxLines - 1] += '...'
-  return preview
 }
 
 /** Joins all text blocks of a tool result into one string, stripping carriage returns. */
@@ -85,10 +126,7 @@ export function renderExpandableText({
   }
 
   if (remaining > 0) {
-    text += `${theme.fg('muted', `\n... (${remaining} more lines,`)} ${keyHint(
-      'app.tools.expand',
-      'to expand',
-    )})`
+    text += `\n${expandHint(remaining, theme)}`
   }
 
   if (truncation) {

--- a/tooling/shared/src/ui.ts
+++ b/tooling/shared/src/ui.ts
@@ -13,7 +13,6 @@ import {
 import type { Component } from '@earendil-works/pi-tui'
 import { Text, truncateToWidth } from '@earendil-works/pi-tui'
 
-/** pi's standard hint for content hidden behind the expand keybinding. */
 function expandHint(hidden: number, theme: Theme): string {
   return `${theme.fg('muted', `... (${hidden} more lines,`)} ${keyHint(
     'app.tools.expand',
@@ -23,18 +22,15 @@ function expandHint(hidden: number, theme: Theme): string {
 
 export interface TextPreviewOptions {
   text: string
-  /** Visual lines to show before the rest is folded behind the expand hint. */
   maxLines: number
   expanded: boolean
   theme: Theme
-  /** Theme color applied to the preview body. */
   color?: ThemeColor
 }
 
 /**
- * Previews `text` capped at `maxLines` *visual* lines: lines as the terminal
- * wraps them at the actual render width, so one long paragraph previews as its
- * first wrapped lines instead of a wall of text.
+ * Previews `text` capped at `maxLines` lines as the terminal wraps them at the
+ * real render width, so a long paragraph does not preview as a wall of text.
  */
 export class TextPreview implements Component {
   private readonly body: Text
@@ -49,7 +45,7 @@ export class TextPreview implements Component {
     theme,
     color = 'dim',
   }: TextPreviewOptions) {
-    // Color per source line; wrapping carries the codes onto each visual line.
+    // Color per source line: wrapping re-emits the codes on each visual line.
     const styled = text
       .split('\n')
       .map((line) => theme.fg(color, line))


### PR DESCRIPTION
Closes #40.

**WIP — open for iteration.**

## What this does

A subagent row stops redrawing while the child runs. It paints exactly twice: once when the child reports its session id, once when the run finishes. Live usage stats and thinking traces are gone — every one of those updates changed a line, and a changed line above the viewport top makes pi's TUI repaint screen + scrollback, so rows that had scrolled out of view kept yanking the viewport around.

The visibility they used to provide moves to the `session` row: children now persist a real session, so `pi --session <id>` opens what the subagent actually did.

```text
subagent Investigate the failing test
  Investigate why the auth integration test fails on CI but passes locally. Look
  at the test setup, the fixtures it loads and any environment differences
  between the CI container and a dev machine.
  ... (4 more lines, ctrl+o to expand)

  cwd      /some/other/path
  model    anthropic/claude-sonnet-4-5:high
  session  019fd2ff-cca1-7a91-866c-7eedf6bc222c

  ✓ 4 turns 12 tools ↑12k ↓3.0k $0.0412 1m22s
  Root cause: the CI image pins an older openssl, so the fixture's certificate...
```

## Changes

- **`runner.ts`** — child spawns with `--session-dir <agentDir>/sessions/subagents --name <description>` instead of `--no-session`. The stdout decoder is now a union of the `session` header and `message_end`; the first header reports the session id (the single live update) and is kept on the result so failures carry it too. `SubagentSnapshot` → `SubagentResult` (+ `sessionId`, `durationMs`); thinking folding and the codex `<!-- -->` stripping are gone.
- **`index.ts`** — `renderCall` is title + a width-aware 3-line prompt preview with the standard expand hint (`ctrl+o` shows the full prompt); model/cwd moved out of the title. `renderResult` renders the metadata list (`cwd` only when it differs from the parent's cwd, `model` seeded at call time, full session uuid), then the stats line, then the output. While running: metadata only, no status line.
- **`utils.ts`** — `subagentSessionDir()`, `formatStats()` (turns, tools, tokens, cost, wall-clock; model no longer repeated).
- **`@pi-plugins/shared`** — `previewLines` replaced by a `TextPreview` component that wraps at the real render width; the expand hint is now one helper shared with `renderExpandableText`. Adds `@earendil-works/pi-tui` as a peer dep.
- README + a `minor` changeset.

## Verification

`ci` (format, lint, type-check, build) passes. The repo has no test runner, so this was checked with throwaway probes:

- live child run → session id captured exactly once, session file written to `~/.pi/agent/sessions/subagents/` with the `--name`, `durationMs` set; `SessionManager.listAll()` resolves it by id while the project scope does not list it.
- failure path (bad model) → error still carries the partial result.
- render harness at width 100 for collapsed/expanded call, running, done, other-cwd, failed and no-metadata rows.

## Worth discussing

- `pi --session <id>` resolves the child session from anywhere, but because it lives outside the project directory pi offers to **fork** it into your cwd instead of opening in place; passing the session file path opens it directly. Documented in the README — is the fork prompt acceptable, or should the README lead with the path form?
- Cache read/write tokens (`R…`/`W…`) are still in the stats line, unlike the sketch in #40. Kept from the previous behaviour — say the word and they go.
- No session cleanup, per the decision in the issue. Child sessions accumulate in `~/.pi/agent/sessions/subagents/`.