### PR TITLE
refactor(shared,checkpoint,fast-mode,subagent,usage,webfetch): unify how plugins run Effects

### DIFF
--- a/.changeset/unify-effect-run-boundary.md
+++ b/.changeset/unify-effect-run-boundary.md
@@ -6,14 +6,7 @@
 '@pi-plugins/webfetch': patch
 ---
 
-Report failures consistently wherever Effect meets pi's promise-based API.
-
-Cancelling a `web_fetch` or `subagent` call previously fed the model
-`All fibers interrupted without error` — Effect squashes an interrupted `Cause`
-into that string, and pi uses a thrown error's message verbatim as the tool
-result. Both tools now report `Operation aborted`, matching pi's builtins.
-
-Defects no longer escape as bare promise rejections from event hooks and
-command handlers, expected failures report their own message instead of a
-pretty-printed `Cause`, and an invalid extension config now warns through the
-UI rather than writing a log line over the TUI.
+Unify how plugins run Effects at pi's promise boundary through shared
+`runTool`/`runHandler` helpers. Cancelled tools now report `Operation aborted`
+like pi's builtins, and failures surface their own message instead of a
+pretty-printed `Cause`.

--- a/.changeset/unify-effect-run-boundary.md
+++ b/.changeset/unify-effect-run-boundary.md
@@ -1,0 +1,19 @@
+---
+'@pi-plugins/checkpoint': patch
+'@pi-plugins/fast-mode': patch
+'@pi-plugins/subagent': patch
+'@pi-plugins/usage': patch
+'@pi-plugins/webfetch': patch
+---
+
+Report failures consistently wherever Effect meets pi's promise-based API.
+
+Cancelling a `web_fetch` or `subagent` call previously fed the model
+`All fibers interrupted without error` — Effect squashes an interrupted `Cause`
+into that string, and pi uses a thrown error's message verbatim as the tool
+result. Both tools now report `Operation aborted`, matching pi's builtins.
+
+Defects no longer escape as bare promise rejections from event hooks and
+command handlers, expected failures report their own message instead of a
+pretty-printed `Cause`, and an invalid extension config now warns through the
+UI rather than writing a log line over the TUI.

--- a/.changeset/webfetch-timeout-error-message.md
+++ b/.changeset/webfetch-timeout-error-message.md
@@ -1,0 +1,8 @@
+---
+'@pi-plugins/webfetch': patch
+---
+
+Fix a `web_fetch` timeout killing the agent's next turn: Effect's `Cause.TimeoutError`
+carries an `undefined` message, which pi persists as a text block with no `text` and
+then crashes its token estimator on (earendil-works/pi#7660). Timeouts now fail with a
+real message, and any error escaping the tool without one is coerced.

--- a/.changeset/webfetch-timeout-error-message.md
+++ b/.changeset/webfetch-timeout-error-message.md
@@ -2,7 +2,5 @@
 '@pi-plugins/webfetch': patch
 ---
 
-Fix a `web_fetch` timeout killing the agent's next turn: Effect's `Cause.TimeoutError`
-carries an `undefined` message, which pi persists as a text block with no `text` and
-then crashes its token estimator on (earendil-works/pi#7660). Timeouts now fail with a
-real message, and any error escaping the tool without one is coerced.
+Fix a `web_fetch` timeout killing the agent's next turn (earendil-works/pi#7660):
+timeouts now fail with a real error message instead of an `undefined` one.

--- a/plugins/checkpoint/package.json
+++ b/plugins/checkpoint/package.json
@@ -52,6 +52,7 @@
     "@earendil-works/pi-coding-agent": "0.83.0",
     "@pi-plugins/fmt": "workspace:*",
     "@pi-plugins/lint": "workspace:*",
+    "@pi-plugins/shared": "workspace:*",
     "@pi-plugins/tsconfig": "workspace:*",
     "@types/node": "26.1.2",
     "oxfmt": "0.62.0",

--- a/plugins/checkpoint/src/index.ts
+++ b/plugins/checkpoint/src/index.ts
@@ -4,6 +4,7 @@ import type {
   SessionEntry,
 } from '@earendil-works/pi-coding-agent'
 import * as NodeServices from '@effect/platform-node/NodeServices'
+import { runHandler } from '@pi-plugins/shared/run'
 import { Array, Effect, Option, pipe, Schema } from 'effect'
 import { Snapshotter, SnapshotterError } from './snapshot'
 
@@ -74,20 +75,24 @@ export default function checkpoint(pi: ExtensionAPI) {
 
   pi.on('session_start', async (_event, ctx) => {
     // Only active inside git worktrees.
-    snapshotter = await Effect.runPromise(
+    snapshotter = await runHandler(
       Snapshotter.make(ctx.cwd).pipe(
         Effect.provide(NodeServices.layer),
-        Effect.catch((error) =>
-          Effect.sync(() => {
-            const expected =
-              error instanceof SnapshotterError && error.kind === 'NotAWorktree'
-            if (ctx.hasUI && !expected) {
-              ctx.ui.notify(`Checkpoints disabled: ${error.message}`, 'warning')
-            }
-            return undefined
-          }),
+        // Being outside a worktree is the normal way to have no snapshotter.
+        Effect.catchIf(
+          (error) =>
+            error instanceof SnapshotterError && error.kind === 'NotAWorktree',
+          () => Effect.succeed(undefined),
         ),
       ),
+      {
+        onError: (message) => {
+          if (ctx.hasUI) {
+            ctx.ui.notify(`Checkpoints disabled: ${message}`, 'warning')
+          }
+          return undefined
+        },
+      },
     )
   })
 
@@ -102,9 +107,7 @@ export default function checkpoint(pi: ExtensionAPI) {
       return
     }
     // Current worktree state as a tree hash, or undefined when tracking fails.
-    const tree = await Effect.runPromise(
-      snapshotter.track().pipe(Effect.orElseSucceed(() => undefined)),
-    )
+    const tree = await runHandler(snapshotter.track())
     if (!tree) {
       return
     }
@@ -134,21 +137,23 @@ export default function checkpoint(pi: ExtensionAPI) {
         return undefined
       }
 
-      await Effect.runPromise(
+      await runHandler(
         snapshotter.cleanup().pipe(
-          Effect.match({
-            onSuccess: (tree) => {
+          Effect.tap((tree) =>
+            Effect.sync(() => {
               const session = ctx.sessionManager
               if (nearestCheckpoint(session, session.getLeafId()) !== tree) {
                 pi.appendEntry(CHECKPOINT_TYPE, { tree })
               }
               ctx.ui.notify('File checkpoint history cleaned up', 'info')
-            },
-            onFailure: (error) => {
-              ctx.ui.notify(`Checkpoint cleanup failed: ${error.message}`, 'error')
-            },
-          }),
+            }),
+          ),
         ),
+        {
+          onError: (message) => {
+            ctx.ui.notify(`Checkpoint cleanup failed: ${message}`, 'error')
+          },
+        },
       )
     },
   })
@@ -163,9 +168,7 @@ export default function checkpoint(pi: ExtensionAPI) {
       return undefined
     }
 
-    const current = await Effect.runPromise(
-      snapshotter.track().pipe(Effect.orElseSucceed(() => undefined)),
-    )
+    const current = await runHandler(snapshotter.track())
     if (!current || current === target) {
       return undefined
     }
@@ -184,19 +187,19 @@ export default function checkpoint(pi: ExtensionAPI) {
       pi.appendEntry(CHECKPOINT_TYPE, { tree: current })
     }
 
-    return Effect.runPromise(
+    return runHandler(
       snapshotter.restore(target).pipe(
-        Effect.match({
-          onSuccess: () => {
-            ctx.ui.notify('Files restored to the selected point', 'info')
-            return undefined
-          },
-          onFailure: (error) => {
-            ctx.ui.notify(`File restore failed: ${error.message}`, 'error')
-            return { cancel: true }
-          },
+        Effect.map(() => {
+          ctx.ui.notify('Files restored to the selected point', 'info')
+          return undefined
         }),
       ),
+      {
+        onError: (message) => {
+          ctx.ui.notify(`File restore failed: ${message}`, 'error')
+          return { cancel: true }
+        },
+      },
     )
   })
 }

--- a/plugins/checkpoint/tsdown.config.ts
+++ b/plugins/checkpoint/tsdown.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'tsdown'
 export default defineConfig({
   platform: 'node',
   exports: true,
+  deps: {
+    alwaysBundle: ['@pi-plugins/shared'],
+  },
   sourcemap: true,
   dts: {
     sourcemap: true,

--- a/plugins/fast-mode/src/index.ts
+++ b/plugins/fast-mode/src/index.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
-import * as NodeServices from '@effect/platform-node/NodeServices'
-import { loadExtensionConfig, setStatuslineSegment } from '@pi-plugins/shared'
+import { loadExtensionConfig } from '@pi-plugins/shared/config'
+import { setStatuslineSegment } from '@pi-plugins/shared/statusline'
 import {
   Array,
   Data,
@@ -140,12 +140,7 @@ export default function fastMode(pi: ExtensionAPI) {
   }
 
   pi.on('session_start', async (_event, ctx) => {
-    config = await Effect.runPromise(
-      loadExtensionConfig(FastModeConfig, EXTENSION_ID).pipe(
-        Effect.orElseSucceed(() => config),
-        Effect.provide(NodeServices.layer),
-      ),
-    )
+    config = await loadExtensionConfig(ctx, FastModeConfig, EXTENSION_ID, config)
     enabled = pi.getFlag('fast') === true || config.enabled
     updateStatus(ctx)
   })

--- a/plugins/speed/src/index.ts
+++ b/plugins/speed/src/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
-import { setStatuslineSegment } from '@pi-plugins/shared'
+import { setStatuslineSegment } from '@pi-plugins/shared/statusline'
 import { Effect } from 'effect'
 import { recentText, streamingText } from './render'
 import { SpeedTracker } from './service'
@@ -7,6 +7,8 @@ import { SpeedTracker } from './service'
 const SEGMENT_KEY = 'speed'
 
 export default function speed(pi: ExtensionAPI) {
+  // Plugin setup is synchronous. The shared run helpers cover only async
+  // boundaries.
   const tracker = Effect.runSync(SpeedTracker.make)
 
   function showWidget(ctx: ExtensionContext, text: string | undefined): void {

--- a/plugins/subagent/src/index.ts
+++ b/plugins/subagent/src/index.ts
@@ -2,7 +2,8 @@ import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { Text } from '@earendil-works/pi-tui'
 import * as NodeServices from '@effect/platform-node/NodeServices'
-import { ExpandableText, TextPreview } from '@pi-plugins/shared'
+import { runTool } from '@pi-plugins/shared/run'
+import { ExpandableText, TextPreview } from '@pi-plugins/shared/ui'
 import { Effect } from 'effect'
 import { Type, type Static } from 'typebox'
 import {
@@ -162,7 +163,7 @@ export default function subagent(pi: ExtensionAPI) {
         Effect.provide(NodeServices.layer),
       )
 
-      return await Effect.runPromise(program, { signal })
+      return await runTool(program, { signal })
     },
     renderCall(args, theme, { expanded }) {
       const title = new Text(

--- a/plugins/subagent/src/utils.ts
+++ b/plugins/subagent/src/utils.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path'
 import { getAgentDir, truncateHead } from '@earendil-works/pi-coding-agent'
-import { formatTruncationNotice } from '@pi-plugins/shared'
+import { formatTruncationNotice } from '@pi-plugins/shared/ui'
 import type { SubagentResult } from './runner'
 
 /**

--- a/plugins/usage/src/index.ts
+++ b/plugins/usage/src/index.ts
@@ -115,12 +115,16 @@ export default function usage(pi: ExtensionAPI): void {
         : codexWidgetLimits(yield* service.codex(), new Date())
     }).pipe(Effect.provide(UsageService.layer(ctx.modelRegistry)))
 
-    // On failure keep whatever is shown; /usage reports errors explicitly.
-    const limits = await runHandler(program)
-    inFlight.delete(provider)
-    // Record the attempt time even on failure so a broken provider (e.g. not
-    // logged in) is not re-queried on every event.
-    fetchedAt.set(provider, Date.now())
+    // On failure keep whatever is shown. /usage reports errors explicitly.
+    let limits: WidgetLimit[] | undefined
+    try {
+      limits = await runHandler(program)
+    } finally {
+      inFlight.delete(provider)
+      // Record the attempt time even on failure so a broken provider (e.g. not
+      // logged in) is not re-queried on every event.
+      fetchedAt.set(provider, Date.now())
+    }
     if (limits !== undefined) {
       limitsCache.set(provider, limits)
       renderWidget(ctx)

--- a/plugins/usage/src/index.ts
+++ b/plugins/usage/src/index.ts
@@ -1,7 +1,8 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
-import * as NodeServices from '@effect/platform-node/NodeServices'
-import { loadExtensionConfig, setStatuslineSegment } from '@pi-plugins/shared'
-import { Cause, Effect, Exit, Schema } from 'effect'
+import { loadExtensionConfig } from '@pi-plugins/shared/config'
+import { runHandler } from '@pi-plugins/shared/run'
+import { setStatuslineSegment } from '@pi-plugins/shared/statusline'
+import { Effect, Schema } from 'effect'
 import {
   claudeSection,
   codexSection,
@@ -114,25 +115,20 @@ export default function usage(pi: ExtensionAPI): void {
         : codexWidgetLimits(yield* service.codex(), new Date())
     }).pipe(Effect.provide(UsageService.layer(ctx.modelRegistry)))
 
-    const exit = await Effect.runPromiseExit(program)
+    // On failure keep whatever is shown; /usage reports errors explicitly.
+    const limits = await runHandler(program)
     inFlight.delete(provider)
     // Record the attempt time even on failure so a broken provider (e.g. not
     // logged in) is not re-queried on every event.
     fetchedAt.set(provider, Date.now())
-    if (Exit.isSuccess(exit)) {
-      limitsCache.set(provider, exit.value)
+    if (limits !== undefined) {
+      limitsCache.set(provider, limits)
       renderWidget(ctx)
     }
-    // On failure keep whatever is shown; /usage reports errors explicitly.
   }
 
   pi.on('session_start', async (_event, ctx) => {
-    config = await Effect.runPromise(
-      loadExtensionConfig(UsageConfig, EXTENSION_ID).pipe(
-        Effect.orElseSucceed(() => config),
-        Effect.provide(NodeServices.layer),
-      ),
-    )
+    config = await loadExtensionConfig(ctx, UsageConfig, EXTENSION_ID, config)
     await refreshWidget(ctx)
   })
 
@@ -200,16 +196,15 @@ export default function usage(pi: ExtensionAPI): void {
           }))
       }).pipe(Effect.provide(UsageService.layer(ctx.modelRegistry)))
 
-      const exit = await Effect.runPromiseExit(program)
-      Exit.match(exit, {
-        onSuccess: (messages) => {
-          for (const { report, severity } of messages) {
-            ctx.ui.notify(report, severity)
-          }
+      const messages = await runHandler(program, {
+        onError: (message) => {
+          ctx.ui.notify(`Failed to fetch usage: ${message}`, 'error')
+          return []
         },
-        onFailure: (cause) =>
-          ctx.ui.notify(`Failed to fetch usage: ${Cause.pretty(cause)}`, 'error'),
       })
+      for (const { report, severity } of messages) {
+        ctx.ui.notify(report, severity)
+      }
       // The command fetched fresh data for both providers — reuse it.
       renderWidget(ctx)
     },

--- a/plugins/webfetch/src/fetch.ts
+++ b/plugins/webfetch/src/fetch.ts
@@ -1,5 +1,4 @@
-import { Context, Duration, Effect, Layer, Schedule } from 'effect'
-import type { TimeoutError } from 'effect/Cause'
+import { Context, Duration, Effect, Layer, Schedule, Schema } from 'effect'
 import {
   FetchHttpClient,
   HttpClient,
@@ -9,6 +8,13 @@ import {
 import { HtmlConverter, HtmlConverterError } from './converter'
 
 export type WebFetchFormat = 'markdown' | 'html'
+
+export class WebFetchTimeoutError extends Schema.TaggedErrorClass<WebFetchTimeoutError>()(
+  '@pi-plugins/webfetch/WebFetchTimeoutError',
+  {
+    message: Schema.String,
+  },
+) {}
 
 const ACCEPT_HEADERS: Record<WebFetchFormat, string> = {
   markdown:
@@ -41,7 +47,7 @@ interface WebFetchService {
     timeout: Duration.Input
   }) => Effect.Effect<
     string,
-    HtmlConverterError | HttpClientError.HttpClientError | TimeoutError
+    HtmlConverterError | HttpClientError.HttpClientError | WebFetchTimeoutError
   >
 }
 
@@ -86,7 +92,15 @@ export class WebFetch extends Context.Service<WebFetch, WebFetchService>()(
         },
         (_, options) =>
           _.pipe(
-            Effect.timeout(options.timeout),
+            Effect.timeoutOrElse({
+              duration: options.timeout,
+              orElse: () =>
+                new WebFetchTimeoutError({
+                  message: `GET ${options.url} timed out after ${Duration.format(
+                    Duration.fromInputUnsafe(options.timeout),
+                  )}`,
+                }),
+            }),
             Effect.withSpan('WebFetch.fetch', {
               attributes: { url: options.url, format: options.format },
             }),

--- a/plugins/webfetch/src/index.ts
+++ b/plugins/webfetch/src/index.ts
@@ -62,7 +62,13 @@ export default function webFetch(pi: ExtensionAPI) {
         })
       }).pipe(Effect.provide(WebFetch.layer))
 
-      const content = await Effect.runPromise(program, { signal })
+      const content = await Effect.runPromise(program, { signal }).catch(
+        (error: unknown) => {
+          throw error instanceof Error && error.message
+            ? error
+            : new Error(String(error))
+        },
+      )
       const truncation = truncateHead(content)
 
       return {

--- a/plugins/webfetch/src/index.ts
+++ b/plugins/webfetch/src/index.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, TruncationResult } from '@earendil-works/pi-coding-agent'
 import { truncateHead } from '@earendil-works/pi-coding-agent'
-import { ExpandableText, formatTruncationNotice } from '@pi-plugins/shared'
+import { runTool } from '@pi-plugins/shared/run'
+import { ExpandableText, formatTruncationNotice } from '@pi-plugins/shared/ui'
 import { Duration, Effect, Number } from 'effect'
 import { Type, type Static } from 'typebox'
 import { WebFetch, type WebFetchFormat } from './fetch'
@@ -62,14 +63,7 @@ export default function webFetch(pi: ExtensionAPI) {
         })
       }).pipe(Effect.provide(WebFetch.layer))
 
-      const content = await Effect.runPromise(program, { signal }).catch(
-        (error: unknown) => {
-          throw error instanceof Error && error.message
-            ? error
-            : new Error(String(error))
-        },
-      )
-      const truncation = truncateHead(content)
+      const truncation = truncateHead(await runTool(program, { signal }))
 
       return {
         content: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@pi-plugins/lint':
         specifier: workspace:*
         version: link:../../tooling/lint
+      '@pi-plugins/shared':
+        specifier: workspace:*
+        version: link:../../tooling/shared
       '@pi-plugins/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
@@ -419,6 +422,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: 0.83.0
         version: 0.83.0
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.103
+        version: 4.0.0-beta.103(effect@4.0.0-beta.103)(ioredis@5.11.1)
       '@pi-plugins/fmt':
         specifier: workspace:*
         version: link:../fmt

--- a/tooling/shared/package.json
+++ b/tooling/shared/package.json
@@ -5,7 +5,10 @@
   "description": "Shared utilities for pi-plugins extensions.",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
+    "./config": "./src/config.ts",
+    "./run": "./src/run.ts",
+    "./statusline": "./src/statusline.ts",
+    "./ui": "./src/ui.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -18,6 +21,7 @@
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "0.83.0",
     "@earendil-works/pi-tui": "0.83.0",
+    "@effect/platform-node": "4.0.0-beta.103",
     "@pi-plugins/fmt": "workspace:*",
     "@pi-plugins/lint": "workspace:*",
     "@pi-plugins/tsconfig": "workspace:*",
@@ -29,6 +33,7 @@
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*",
+    "@effect/platform-node": "*",
     "effect": "*"
   }
 }

--- a/tooling/shared/src/config.ts
+++ b/tooling/shared/src/config.ts
@@ -1,25 +1,48 @@
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent'
 import { getAgentDir } from '@earendil-works/pi-coding-agent'
-import { Effect, FileSystem, Path, Schema } from 'effect'
+import * as NodeServices from '@effect/platform-node/NodeServices'
+import { Effect, FileSystem, Path, PlatformError, Schema } from 'effect'
+import { runHandler } from './run'
 
 /**
- * Loads an extension's JSON config from `<agent-dir>/extensions/<name>.json` and
- * validates it with `schema`.
+ * A missing config file yields `defaults` silently. An unreadable or invalid
+ * one warns and yields `defaults`, so a typo downgrades the extension rather
+ * than breaking it.
  */
-export const loadExtensionConfig = Effect.fnUntraced(function* <
-  S extends Schema.Top,
->(schema: S, name: string) {
-  const fs = yield* FileSystem.FileSystem
-  const path = yield* Path.Path
-
-  const file = path.join(getAgentDir(), 'extensions', `${name}.json`)
-  return yield* fs.readFileString(file).pipe(
-    Effect.flatMap(Schema.decodeEffect(Schema.fromJsonString(schema))),
-    Effect.tapError((error) =>
-      error._tag === 'PlatformError' && error.reason._tag === 'NotFound'
-        ? Effect.void
-        : Effect.logWarning(
-            `Could not load ${name} config. [${error._tag}]: ${error.message}`,
-          ),
+export const loadExtensionConfig = Effect.fnUntraced(
+  function* <S extends Schema.Codec<unknown>>(
+    _ctx: ExtensionContext,
+    schema: S,
+    name: string,
+    _defaults: S['Type'],
+  ): Effect.fn.Return<
+    S['Type'],
+    Schema.SchemaError | PlatformError.PlatformError,
+    FileSystem.FileSystem | Path.Path
+  > {
+    const fs = yield* FileSystem.FileSystem
+    const path = yield* Path.Path
+    const file = path.join(getAgentDir(), 'extensions', `${name}.json`)
+    const contents = yield* fs.readFileString(file)
+    return yield* Schema.decodeEffect(Schema.fromJsonString(schema))(contents)
+  },
+  (load, ctx, _schema, name, defaults) =>
+    runHandler(
+      load.pipe(
+        Effect.catchIf(
+          (error) =>
+            error._tag === 'PlatformError' && error.reason._tag === 'NotFound',
+          () => Effect.succeed(defaults),
+        ),
+        Effect.provide(NodeServices.layer),
+      ),
+      {
+        onError: (message) => {
+          if (ctx.hasUI) {
+            ctx.ui.notify(`Ignoring invalid ${name} config: ${message}`, 'warning')
+          }
+          return defaults
+        },
+      },
     ),
-  )
-})
+)

--- a/tooling/shared/src/index.ts
+++ b/tooling/shared/src/index.ts
@@ -1,3 +1,0 @@
-export * from './config'
-export * from './statusline'
-export * from './ui'

--- a/tooling/shared/src/run.ts
+++ b/tooling/shared/src/run.ts
@@ -1,0 +1,70 @@
+import { Cause, Effect, Exit, Inspectable } from 'effect'
+
+// What pi's own tools throw for a cancelled run, so interrupted plugin runs
+// read like interrupted builtins.
+const ABORT_MESSAGE = 'Operation aborted'
+
+export interface RunOptions {
+  readonly signal?: AbortSignal | undefined
+}
+
+// Defects keep their stack because they are bugs, and win over failures in a
+// mixed cause.
+function causeMessage(cause: Cause.Cause<unknown>): string {
+  if (Cause.hasInterruptsOnly(cause)) {
+    return ABORT_MESSAGE
+  }
+  if (Cause.hasDies(cause)) {
+    return Cause.pretty(cause)
+  }
+  return cause.reasons
+    .filter(Cause.isFailReason)
+    .map(({ error }) => {
+      if (error instanceof Error) {
+        return error.message || error.name
+      }
+      return typeof error === 'string' ? error : Inspectable.toStringUnknown(error)
+    })
+    .join('\n')
+}
+
+/**
+ * Failure rejects with an `Error` whose message is what the model reads back
+ * as the tool result, so it is written for the model rather than for a log.
+ */
+export async function runTool<A, E>(
+  effect: Effect.Effect<A, E>,
+  options?: RunOptions,
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(effect, options)
+  if (Exit.isFailure(exit)) {
+    throw new Error(causeMessage(exit.cause))
+  }
+  return exit.value
+}
+
+export interface RunHandlerOptions<B> {
+  readonly onError?: (message: string) => B
+}
+
+/**
+ * For boundaries pi does not report failures from (event hooks, commands,
+ * background work). Never rejects. Without `onError`, failures vanish and
+ * defects log to stderr.
+ */
+export async function runHandler<A, E, B = undefined>(
+  effect: Effect.Effect<A, E>,
+  options?: RunHandlerOptions<B>,
+): Promise<A | B> {
+  const exit = await Effect.runPromiseExit(effect)
+  if (Exit.isSuccess(exit)) {
+    return exit.value
+  }
+  if (options?.onError) {
+    return options.onError(causeMessage(exit.cause))
+  }
+  if (Cause.hasDies(exit.cause)) {
+    console.error(causeMessage(exit.cause))
+  }
+  return undefined as B
+}

--- a/tooling/shared/src/run.ts
+++ b/tooling/shared/src/run.ts
@@ -48,9 +48,10 @@ export interface RunHandlerOptions<B> {
 }
 
 /**
- * For boundaries pi does not report failures from (event hooks, commands,
- * background work). Never rejects. Without `onError`, failures vanish and
- * defects log to stderr.
+ * For boundaries where pi reports rejections but expected failures should
+ * degrade gracefully (event hooks, commands, background work). Expected
+ * failures and interrupts never reject. Without `onError` they vanish, while
+ * defects rethrow so pi's handler boundary reports the bug.
  */
 export async function runHandler<A, E, B = undefined>(
   effect: Effect.Effect<A, E>,
@@ -63,8 +64,9 @@ export async function runHandler<A, E, B = undefined>(
   if (options?.onError) {
     return options.onError(causeMessage(exit.cause))
   }
-  if (Cause.hasDies(exit.cause)) {
-    console.error(causeMessage(exit.cause))
+  const die = exit.cause.reasons.find(Cause.isDieReason)
+  if (die !== undefined) {
+    throw die.defect
   }
   return undefined as B
 }


### PR DESCRIPTION
Every plugin had hand-rolled its own way of getting from an `Effect` back into
pi's promise-based API — 11 run sites across 5 different shapes, mixing
`runPromise`, `runPromiseExit`, `Effect.match`, `orElseSucceed` and a bespoke
`.catch` re-wrap.

## The bug this was hiding

`Effect.runPromise` rejects with `causeSquash(cause)`, and an interrupt-only
cause squashes to `new Error("All fibers interrupted without error")`. Pi turns
a thrown `execute` error's message *verbatim* into the tool result the model
reads.

So cancelling a `web_fetch` or `subagent` call fed the model
`All fibers interrupted without error`, while every builtin pi tool — and pi's
own UI for a cancelled row — says `Operation aborted`. Both tools now agree
with the builtins.

Two more leaks in the same class:

- `Effect.match` / `orElseSucceed` / `Effect.catch` only cover the **typed**
  error channel, so defects escaped as bare rejections from every event hook.
  In `session_before_tree` that meant the handler could not return
  `{ cancel: true }` and tree navigation proceeded unguarded.
- `loadExtensionConfig` reported a malformed config with `Effect.logWarning`.
  Effect's default logger writes to `console.log`, pi does not patch console,
  and pi's TUI is a differential inline renderer — so the warning scribbled
  over the UI.

## The shape

There is no single best `run*`, but there is one best core: **always run to an
`Exit` and fold the `Cause` yourself.** What varies is not style — each
boundary has a different destination for failure:

| Boundary | Failure goes to |
| --- | --- |
| tool `execute` | the model, as result text |
| `pi.on(...)` | pi's extension-error channel |
| `registerCommand` | ditto, message only, no stack |

`@pi-plugins/shared/run` exposes that as two boundary-shaped functions over a
shared `Cause` formatter (interrupt-only → `Operation aborted`; any defect →
`Cause.pretty`, keeping the stack and winning over failures in a mixed cause;
otherwise the failures' own messages):

- `runTool(effect, { signal })` — rejects with an `Error` whose message *is*
  the model's tool result.
- `runHandler(effect, { onError })` — expected failures and interrupts never
  reject; without `onError` they vanish. Defects rethrow unwrapped so pi's own
  handler boundary reports them with the original stack, rather than being
  swallowed or written over the TUI. Folding the `Cause` rather than the error
  channel is the point: it is the only construct here that can decide per
  failure *kind*.

11 sites → `runTool` ×2, `runHandler` ×7, `runSync` ×1 (`speed`, already
correct for a total sync effect), and one absorbed into `loadExtensionConfig`.

## Bundled cleanups

- `loadExtensionConfig` now owns its platform services and reports through
  `ctx.ui.notify`. A missing file yields the defaults silently; an unreadable
  or invalid one warns and degrades. Both call sites collapse to one line.
- `shared`'s barrel is replaced by subpath exports. Importing `runHandler` from
  the barrel dragged in `ui.ts`, inlining `@earendil-works/pi-tui` **and all of
  `marked`** into `checkpoint`'s bundle — 72K → 13K.
- `checkpoint`'s `tsdown.config.ts` gains the `alwaysBundle` the other six had.

## Verification

`turbo run check` and `turbo run build` pass. Behaviour was exercised directly
against every branch: tool interrupt / expected failure / defect, handler
defect rethrow (original stack preserved) vs. expected-failure and interrupt
resolving to `undefined`, defect-beats-failure in a mixed cause, and
`loadExtensionConfig` over missing / valid / malformed-JSON / wrong-type files.