### PR TITLE
feat(usage): report GLM coding plan usage

### DIFF
--- a/.changeset/glm-usage.md
+++ b/.changeset/glm-usage.md
@@ -1,0 +1,10 @@
+---
+'@pi-plugins/usage': minor
+---
+
+Add GLM Coding Plan (Z.ai / Zhipu) usage reporting: `/usage` gains a GLM section
+with the 5h and weekly quota windows (percent, reset time, credits used), and the
+status-line widget shows `5h`/`wk` bars while a `zai` or `zai-coding-cn` model is
+active. Credentials are read from the API key stored for the `zai` provider
+(`zai-coding-cn` for the open.bigmodel.cn China platform); `/usage` reports the
+platform you have a key for, preferring the global one.

--- a/.changeset/glm-usage.md
+++ b/.changeset/glm-usage.md
@@ -7,5 +7,5 @@ with the 5h and weekly quota windows (percent, reset time, credits used), and th
 status-line widget shows `5h`/`wk` bars while a `zai` or `zai-coding-cn` model is
 active. It authenticates with the API key pi resolves for the `zai` provider
 (`zai-coding-cn` for the open.bigmodel.cn China platform), whether from `/login` or
-the `ZAI_API_KEY` / `ZAI_CODING_CN_API_KEY` environment variables; `/usage` reports
+the `ZAI_API_KEY` / `ZAI_CODING_CN_API_KEY` environment variables. `/usage` reports
 the platform you have a key for, preferring the global one.

--- a/.changeset/glm-usage.md
+++ b/.changeset/glm-usage.md
@@ -2,10 +2,4 @@
 '@pi-plugins/usage': minor
 ---
 
-Add GLM Coding Plan (Z.ai / Zhipu) usage reporting: `/usage` gains a GLM section
-with the 5h and weekly quota windows (percent, reset time, credits used), and the
-status-line widget shows `5h`/`wk` bars while a `zai` or `zai-coding-cn` model is
-active. It authenticates with the API key pi resolves for the `zai` provider
-(`zai-coding-cn` for the open.bigmodel.cn China platform), whether from `/login` or
-the `ZAI_API_KEY` / `ZAI_CODING_CN_API_KEY` environment variables. `/usage` reports
-the platform you have a key for, preferring the global one.
+Report Z.ai / Zhipu GLM Coding Plan usage in `/usage` and the status-line widget.

--- a/.changeset/glm-usage.md
+++ b/.changeset/glm-usage.md
@@ -5,6 +5,7 @@
 Add GLM Coding Plan (Z.ai / Zhipu) usage reporting: `/usage` gains a GLM section
 with the 5h and weekly quota windows (percent, reset time, credits used), and the
 status-line widget shows `5h`/`wk` bars while a `zai` or `zai-coding-cn` model is
-active. Credentials are read from the API key stored for the `zai` provider
-(`zai-coding-cn` for the open.bigmodel.cn China platform); `/usage` reports the
-platform you have a key for, preferring the global one.
+active. It authenticates with the API key pi resolves for the `zai` provider
+(`zai-coding-cn` for the open.bigmodel.cn China platform), whether from `/login` or
+the `ZAI_API_KEY` / `ZAI_CODING_CN_API_KEY` environment variables; `/usage` reports
+the platform you have a key for, preferring the global one.

--- a/.changeset/usage-widget-drop-background-refresh.md
+++ b/.changeset/usage-widget-drop-background-refresh.md
@@ -2,6 +2,6 @@
 '@pi-plugins/usage': patch
 ---
 
-Drop the widget's background refresh; it hit the usage endpoints' rate limits and
+Drop the widget's background refresh. It hit the usage endpoints' rate limits and
 often left the widget empty. It refreshes at most every 30 seconds on session
 start, model select and `agent_settled` again.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # pi-plugins
 
 This repository is a pnpm/Turbo monorepo containing plugins/extensions for the
-pi-agent harness. Pi-agent plugins live under `plugins/`; shared tooling and support
+pi-agent harness. Pi-agent plugins live under `plugins/`. Shared tooling and support
 packages live under `tooling/`.
 
 ## Validation

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -11,8 +11,8 @@ exploring the codebase.
   `plugins/<name>/docs/adr/` and `tooling/<name>/docs/adr/` for package-scoped
   decisions.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence;
-don't suggest creating them upfront. The `/domain-modeling` skill (reached via
+If any of these files don't exist, **proceed silently**. Don't flag their absence or
+suggest creating them upfront. The `/domain-modeling` skill (reached via
 `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when
 terms or decisions actually get resolved.
 
@@ -39,8 +39,8 @@ workspace package.
 ```
 
 Not every package has these files, and that's expected — `/domain-modeling` creates
-them lazily as terms and decisions actually get resolved. Read the ones that exist;
-proceed silently past the ones that don't.
+them lazily as terms and decisions actually get resolved. Read the ones that exist
+and proceed silently past the ones that don't.
 
 ## Use the glossary's vocabulary
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -23,7 +23,7 @@ clone.
 ## Pull requests as a triage surface
 
 **PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as
-feature requests; `/triage` reads this flag.)_
+feature requests. `/triage` reads this flag.)_
 
 When set to `yes`, PRs run through the same labels and states as issues, using the
 `gh pr` equivalents:
@@ -71,7 +71,7 @@ Used by `/wayfinder`. The **map** is a single issue with **child** issues as tic
 - **Frontier query**: list the map's open children (`gh issue list --state open`,
   scoped to the map's sub-issues / task list), drop any with an open blocker
   (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by`
-  line) or an assignee; first in map order wins.
+  line) or an assignee. First in map order wins.
 - **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
 - **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`,
   then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/plugins/claude-oauth/scripts/claude-trace.ts
+++ b/plugins/claude-oauth/scripts/claude-trace.ts
@@ -28,10 +28,10 @@
  * Options:
  *   --message <text>   Prompt to send (default exercises fingerprint indices 4/7/20)
  *   --command <cmd>    Claude binary (default: claude)
- *   --port <n>         Proxy port (default: 8118; 0 = random)
+ *   --port <n>         Proxy port (default: 8118, or 0 for random)
  *   --timeout <ms>     Overall timeout (default: 120000)
  *   --skip <substr>    Skip requests whose model contains this (default: haiku)
- *   --manual           Do not spawn claude; print the env and wait for you to run it
+ *   --manual           Print the env instead of spawning claude, then wait for you to run it
  *   --write            Patch src/constants.ts in place with the captured values
  *   --json             Print the raw captured exchange as JSON
  *   --keep-cert        Leave the generated debug cert on disk (for debugging)
@@ -76,7 +76,7 @@ const BACKSLASH = 0x5c
 const OPEN_BRACKET = 0x5b
 const CLOSE_BRACKET = 0x5d
 
-// ── xxh64 (mirror of src/utils.ts; kept inline so the script has no imports) ──
+// ── xxh64 (mirror of src/utils.ts, kept inline so the script has no imports) ──
 
 const MASK = (1n << 64n) - 1n
 const P1 = 11400714785074694791n
@@ -281,7 +281,7 @@ const HELP = readFileSync(fileURLToPath(import.meta.url), 'utf8')
 function parseArgs(argv: readonly string[]): Options | 'help' {
   const opts: Options = {
     // >20 chars so the billing-fingerprint indices (4, 7, 20) hit real characters
-    // instead of all falling back to '0'; otherwise that check never exercises them.
+    // instead of all falling back to '0'. Otherwise that check never exercises them.
     message: 'Reply with exactly: ok',
     command: 'claude',
     port: 8118,
@@ -385,7 +385,7 @@ function generateDebugCert(): DebugCert {
   }
 }
 
-// ── minimal HTTP request parser (Content-Length only; no chunked requests) ────
+// ── minimal HTTP request parser (Content-Length only, no chunked requests) ────
 
 interface CapturedRequest {
   method: string
@@ -744,7 +744,7 @@ function extract(request: CapturedRequest): Extracted {
   try {
     body = JSON.parse(request.body) as AnthropicBody
   } catch {
-    // leave body empty; extraction just skips body-derived values
+    // leave body empty as extraction just skips body-derived values
   }
   const systemBlocks = body.system ?? []
   const billingText = systemBlocks.find((b) =>
@@ -1219,8 +1219,8 @@ async function run(opts: Options): Promise<void> {
 
     const source = readFileSync(CONSTANTS_FILE, 'utf8')
     const extracted = extract(capture.request)
-    // Claude fingerprints the raw prompt. When we spawn claude we know it exactly;
-    // in --manual mode recover it from the captured (context-wrapped) user message.
+    // Claude fingerprints the raw prompt. When we spawn claude we know it exactly.
+    // In --manual mode recover it from the captured (context-wrapped) user message.
     const rawUserMessage = opts.manual
       ? rawUserPrompt(extracted.firstUserMessage)
       : opts.message

--- a/plugins/claude-oauth/src/cch.ts
+++ b/plugins/claude-oauth/src/cch.ts
@@ -154,7 +154,7 @@ export function wrapFetchForCch(
 
     if (placeholderIdx === -1 || placeholderIdx - searchFrom > CCH_SEARCH_WINDOW) {
       console.warn(
-        '[claude-oauth] cch placeholder present but not anchored; sending request with cch left unset',
+        '[claude-oauth] cch placeholder present but not anchored — sending request with cch left unset',
       )
       return base(input, init)
     }
@@ -167,7 +167,8 @@ export function wrapFetchForCch(
     const inputHeaders =
       init?.headers ?? (input instanceof Request ? input.headers : undefined)
     const headers = new Headers(inputHeaders)
-    // Pi's betas match the request fields it emitted; keep them alongside the baseline.
+    // Pi's betas match the request fields it emitted, so keep them alongside the
+    // baseline.
     const incomingBetaHeader = headers.get('anthropic-beta') ?? ''
     for (const [name, value] of Object.entries(claudeHeaders)) {
       headers.set(name, value)

--- a/plugins/claude-oauth/src/constants.ts
+++ b/plugins/claude-oauth/src/constants.ts
@@ -13,7 +13,7 @@ export const CLAUDE_CODE_BILLING_FINGERPRINT_INDICES = [4, 7, 20] as const
 export const CLAUDE_CODE_BILLING_HEADER_PREFIX = 'x-anthropic-billing-header:'
 export const CCH_PLACEHOLDER = 'cch=00000'
 
-// XXH64 seed for `cch`; pinned to the client and verified by `scripts/claude-trace.ts`.
+// XXH64 seed for `cch`, pinned to the client and verified by `scripts/claude-trace.ts`.
 export const CCH_SEED = 0x4d659218e32a3268n
 
 // pi injects this exact block as system[0] on OAuth requests.

--- a/plugins/claude-oauth/src/system-prompt.ts
+++ b/plugins/claude-oauth/src/system-prompt.ts
@@ -9,7 +9,7 @@ const PI_REMOVAL_ANCHORS = [
 const PI_DOCUMENTATION_HEADING =
   'Pi documentation (read only when the user asks about pi itself,'
 
-// Standalone "pi"/"Pi" only; the lookarounds spare paths and identifiers
+// Standalone "pi"/"Pi" only. The lookarounds spare paths and identifiers
 // (`/pi/`, `pi-plugins`, `@pi`, `pi.mod`, `pi_x`, `pi:1`).
 const PI_WORD = /(?<![/\\.@:_-])\b[Pp]i\b(?![/\\.@:_-])/g
 

--- a/plugins/elapsed/README.md
+++ b/plugins/elapsed/README.md
@@ -36,7 +36,7 @@ spinner, restarting at `0s` for every prompt and disappearing when the agent is 
 - The clock covers one full prompt — the whole agent run, including every turn and
   tool call — not a single LLM request. For per-request timings use
   [`speed`](../speed).
-- It ticks once per second and replaces pi's default `Working...` message; pi's own
+- It ticks once per second and replaces pi's default `Working...` message. Pi's own
   message is restored when the run ends.
 - Interactive (TUI) mode only. In RPC, print, and JSON modes there is no working
   indicator, so the extension stays idle.

--- a/plugins/fast-mode/README.md
+++ b/plugins/fast-mode/README.md
@@ -77,8 +77,8 @@ Optional config file at `<agent-dir>/extensions/fast-mode.json` (typically
 }
 ```
 
-- `enabled`: fast-mode state at session start (`/fast` overrides it for the session;
-  the toggle is not written back to the file).
+- `enabled`: fast-mode state at session start (`/fast` overrides it for the session
+  without writing the toggle back to the file).
 - `models`: the `provider/model-id` keys fast mode applies to. The defaults above are
   used when the file is absent. Models whose API has no fast-mode support are
   ignored.

--- a/plugins/skills/skills/code-review/SKILL.md
+++ b/plugins/skills/skills/code-review/SKILL.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 ---
 
 You are doing a correctness review of a diff: your job is to catch every real bug
-before it ships. Cast a wide net when finding candidates; apply a strict bar when
+before it ships. Cast a wide net when finding candidates but apply a strict bar when
 verifying them. A reportable finding must be:
 
 - **introduced by the diff** — pre-existing issues are out of scope unless the diff
@@ -23,8 +23,8 @@ Run `git diff @{upstream}...HEAD` (or `git diff main...HEAD` / `git diff HEAD~1`
 there's no upstream) to get the unified diff under review. If there are uncommitted
 changes, or the range diff is empty, also run `git diff HEAD` and include the
 working-tree changes in scope. If an argument — a PR number, branch name, or file
-path — was passed to this skill, it appears immediately after these instructions;
-review that target instead.
+path — was passed to this skill, it appears immediately after these instructions.
+Review that target instead.
 
 ## Phase 1 — Find candidates
 
@@ -105,14 +105,14 @@ columns:
 - `#` — 1-based rank, matching the severity order
 - `Priority` — `p0` (drop everything) / `p1` (fix before merge) / `p2` (fix
   eventually) / `p3` (nice to have)
-- `Location` — `` `file:line` `` in backticks; use the file's path as it appears in
+- `Location` — `` `file:line` `` in backticks, using the file's path as it appears in
   the diff
 - `Category` — short kebab-case slug for the bug class (`logic`, `lost-behavior`,
   `broken-contract`, `error-path`, or a more specific slug when one fits better)
-- `Summary` — one matter-of-fact sentence; state severity honestly, don't inflate
+- `Summary` — one matter-of-fact sentence. State severity honestly, don't inflate
 - `Failure scenario` — the concrete inputs, state, or environment that trigger it and
   what goes wrong
-- `Verdict` — `Confirmed` or `Plausible` from the verify pass; `—` if none
+- `Verdict` — `Confirmed` or `Plausible` from the verify pass, or `—` if none
 
 One row per finding, and keep each cell to a single line so the table stays readable.
 If a finding needs a code snippet, put it in a short fenced block below the table,

--- a/plugins/skills/skills/simplify/SKILL.md
+++ b/plugins/skills/skills/simplify/SKILL.md
@@ -18,8 +18,8 @@ Run `git diff @{upstream}...HEAD` (or `git diff main...HEAD` / `git diff HEAD~1`
 there's no upstream) to get the unified diff under review. If there are uncommitted
 changes, or the range diff is empty, also run `git diff HEAD` and include the
 working-tree changes in scope. If an argument — a PR number, branch name, or file
-path — was passed to this skill, it appears immediately after these instructions;
-review that target instead.
+path — was passed to this skill, it appears immediately after these instructions.
+Review that target instead.
 
 ## Phase 1 — Review (4 cleanup agents in parallel)
 
@@ -45,7 +45,7 @@ that does the same job.
 Flag wasted work the diff introduces: redundant computation or repeated I/O,
 independent operations run sequentially, blocking work added to startup or hot paths.
 Also flag long-lived objects built from closures or captured environments — they pin
-the whole enclosing scope for their lifetime; prefer a class/struct that copies only
+the whole enclosing scope for their lifetime. Prefer a class/struct that copies only
 the fields it needs. Name the cheaper alternative.
 
 ### Altitude
@@ -71,11 +71,11 @@ most-impactful first, with these columns:
 | 1   | `src/api/client.ts:88` | reuse    | Re-implements retry-with-backoff that `withRetry()` already provides. | Second copy of the backoff policy to keep in sync with `src/lib/retry.ts`. | Call `withRetry(fn, { attempts: 3 })` instead of the hand-rolled loop. |
 
 - `#` — 1-based rank, matching the impact order
-- `Location` — `` `file:line` `` in backticks; use the file's path as it appears in
+- `Location` — `` `file:line` `` in backticks, using the file's path as it appears in
   the diff
 - `Category` — short kebab-case slug for the angle that produced it (`reuse`,
   `simplification`, `efficiency`, or `altitude`)
-- `Summary` — one matter-of-fact sentence; don't inflate the issue
+- `Summary` — one matter-of-fact sentence. Don't inflate the issue
 - `Cost` — what is concretely duplicated, wasted, or harder to maintain
 - `Suggestion` — the simpler or cheaper form that does the same job
 

--- a/plugins/speed/src/service.ts
+++ b/plugins/speed/src/service.ts
@@ -20,14 +20,14 @@ const MIN_EFFECTIVE_SAMPLES = 5
 const SETTLED_RELATIVE_ERROR = 0.05
 const UNSETTLED_RELATIVE_ERROR = 0.15
 
-// Bartlett lags for the serial-correlation term; past two the weights are noise.
+// Bartlett lags for the serial-correlation term. Past two the weights are noise.
 const HAC_LAGS = 2
 
 // A sample carrying the whole window leaves no residual to correct against.
 const MAX_LEVERAGE = 0.99
 
 // Share of billed reasoning the streamed thinking must cover to count as streamed
-// whole. Chars-per-token varies ~20% between prose, code and JSON; anything under
+// whole. Chars-per-token varies ~20% between prose, code and JSON, so anything under
 // this gap is a summary, not measurement noise.
 const REASONING_STREAMED = 0.6
 
@@ -72,7 +72,7 @@ interface InflightRequest {
   thinkingChars: number
 }
 
-// Splits total weight rather than count; `NaN` when empty.
+// Splits total weight rather than count and is `NaN` when empty.
 function weightedMedian(
   entries: readonly { readonly value: number; readonly weight: number }[],
 ): number {
@@ -121,7 +121,7 @@ function streamedTokens(
         ? reasoning
         : implied
 
-  // The first delta predates the interval; its share is prorated out by
+  // The first delta predates the interval, so its share is prorated out by
   // characters since the opening chunk is routinely a fragment.
   return ((visible + streamedReasoning) * withinInterval) / chars
 }
@@ -182,7 +182,7 @@ function recentSpeed(
 
   // Requests in one turn share a provider node, queue position and context
   // length, so their residuals move together. Bartlett-weighted lags add that
-  // covariance back; the kernel can go negative under alternation, hence the floor.
+  // covariance back. The kernel can go negative under alternation, hence the floor.
   let variance = independent
   for (let lag = 1; lag <= HAC_LAGS; lag++) {
     let covariance = 0
@@ -267,7 +267,7 @@ export class SpeedTracker extends Context.Service<SpeedTracker>()(
           outcome.stopReason === 'aborted' ||
           outcome.outputTokens <= 0
         ) {
-          // A lone delta spans no interval; timing it would read as thousands of tok/s.
+          // A lone delta spans no interval. Timing it would read as thousands of tok/s.
           return
         }
 

--- a/plugins/subagent/src/runner.ts
+++ b/plugins/subagent/src/runner.ts
@@ -208,7 +208,7 @@ export function runSubagent(options: {
       const startedAt = Date.now()
       const handle = yield* ChildProcess.make(invocation.command, invocation.args, {
         cwd: options.cwd,
-        // Overrides a process-wide long retention setting; the explicit value
+        // Overrides a process-wide long retention setting. The explicit value
         // also tells @pi-plugins/claude-oauth not to extend child TTLs.
         env: { PI_CACHE_RETENTION: 'short' },
         extendEnv: true,

--- a/plugins/usage/README.md
+++ b/plugins/usage/README.md
@@ -19,7 +19,7 @@ Expired access tokens are refreshed transparently through pi's auth storage befo
 the usage request is made. The GLM coding plan uses whatever API key pi resolves for
 the `zai` (or `zai-coding-cn`) provider, so `ZAI_API_KEY` / `ZAI_CODING_CN_API_KEY`
 work as well as `/login`. `/usage` reports the platform you have a key for,
-preferring the global one; the widget follows the active model's provider.
+preferring the global one. The widget follows the active model's provider.
 
 ## Install
 

--- a/plugins/usage/README.md
+++ b/plugins/usage/README.md
@@ -5,10 +5,10 @@ subscription plan usage / rate limits for Anthropic Claude (Pro/Max), OpenAI Cod
 (ChatGPT), and Z.ai/Zhipu GLM Coding plans via a `/usage` command and a compact
 status-line widget.
 
-Credentials are read from pi's internal auth store, so anything you have logged into
-with `/login` works out of the box — no extra configuration required:
+Credentials are read from pi's auth store, so anything you have logged into with
+`/login` works out of the box — no extra configuration required:
 
-| Provider           | Endpoint                                                     | Credential (auth store)                         |
+| Provider           | Endpoint                                                     | Credential                                      |
 | ------------------ | ------------------------------------------------------------ | ----------------------------------------------- |
 | Claude             | `GET https://api.anthropic.com/api/oauth/usage`              | `anthropic` OAuth token                         |
 | OpenAI Codex       | `GET https://chatgpt.com/backend-api/wham/usage`             | `openai-codex` OAuth token + ChatGPT account id |
@@ -16,10 +16,10 @@ with `/login` works out of the box — no extra configuration required:
 | GLM Coding (China) | `GET https://open.bigmodel.cn/api/monitor/usage/quota/limit` | `zai-coding-cn` API key                         |
 
 Expired access tokens are refreshed transparently through pi's auth storage before
-the usage request is made. The GLM coding plan authenticates with the API key stored
-for the `zai` (or `zai-coding-cn`) provider. `/usage` reports the platform you have a
-key for, preferring the global one; the widget always follows the active model's
-provider.
+the usage request is made. The GLM coding plan uses whatever API key pi resolves for
+the `zai` (or `zai-coding-cn`) provider, so `ZAI_API_KEY` / `ZAI_CODING_CN_API_KEY`
+work as well as `/login`. `/usage` reports the platform you have a key for,
+preferring the global one; the widget follows the active model's provider.
 
 ## Install
 

--- a/plugins/usage/README.md
+++ b/plugins/usage/README.md
@@ -1,19 +1,25 @@
 # `@pi-plugins/usage`
 
 A [pi-agent](https://github.com/earendil-works/pi) extension that surfaces the
-subscription plan usage / rate limits for Anthropic Claude (Pro/Max) and OpenAI Codex
-(ChatGPT) plans via a `/usage` command and a compact status-line widget.
+subscription plan usage / rate limits for Anthropic Claude (Pro/Max), OpenAI Codex
+(ChatGPT), and Z.ai/Zhipu GLM Coding plans via a `/usage` command and a compact
+status-line widget.
 
 Credentials are read from pi's internal auth store, so anything you have logged into
 with `/login` works out of the box — no extra configuration required:
 
-| Provider     | Endpoint                                         | Credential (auth store)                         |
-| ------------ | ------------------------------------------------ | ----------------------------------------------- |
-| Claude       | `GET https://api.anthropic.com/api/oauth/usage`  | `anthropic` OAuth token                         |
-| OpenAI Codex | `GET https://chatgpt.com/backend-api/wham/usage` | `openai-codex` OAuth token + ChatGPT account id |
+| Provider           | Endpoint                                                     | Credential (auth store)                         |
+| ------------------ | ------------------------------------------------------------ | ----------------------------------------------- |
+| Claude             | `GET https://api.anthropic.com/api/oauth/usage`              | `anthropic` OAuth token                         |
+| OpenAI Codex       | `GET https://chatgpt.com/backend-api/wham/usage`             | `openai-codex` OAuth token + ChatGPT account id |
+| GLM Coding         | `GET https://api.z.ai/api/monitor/usage/quota/limit`         | `zai` API key                                   |
+| GLM Coding (China) | `GET https://open.bigmodel.cn/api/monitor/usage/quota/limit` | `zai-coding-cn` API key                         |
 
 Expired access tokens are refreshed transparently through pi's auth storage before
-the usage request is made.
+the usage request is made. The GLM coding plan authenticates with the API key stored
+for the `zai` (or `zai-coding-cn`) provider. `/usage` reports the platform you have a
+key for, preferring the global one; the widget always follows the active model's
+provider.
 
 ## Install
 
@@ -51,13 +57,17 @@ Claude
 OpenAI Codex (pro)
   5h limit               [████░░░░░░]  42% · resets in 3h 25m
   Week limit             [████████░░]  84% · resets in 4d 2h
+
+GLM Coding (max)
+  Session (5h)           [█░░░░░░░░░]   7% · resets in 4h 17m · 2,096 of 28,000 credits
+  Week                   [░░░░░░░░░░]   1% · resets in 5d 1h · 2,096 of 140,000 credits
 ```
 
 ## Widget
 
-While the active model belongs to a subscription provider (`anthropic` or
-`openai-codex`), the session and weekly rate limits are shown as small progress bars
-on the shared status line above the editor:
+While the active model belongs to a subscription provider (`anthropic`,
+`openai-codex`, `zai`, or `zai-coding-cn`), the session and weekly rate limits are
+shown as small progress bars on the shared status line above the editor:
 
 ```text
 5h ██░░░ 42% (2h) · wk █░░░░ 17% (4d)

--- a/plugins/usage/README.md
+++ b/plugins/usage/README.md
@@ -1,8 +1,7 @@
 # `@pi-plugins/usage`
 
-A [pi-agent](https://github.com/earendil-works/pi) extension that surfaces the
-subscription plan usage / rate limits for Anthropic Claude (Pro/Max), OpenAI Codex
-(ChatGPT), and Z.ai/Zhipu GLM Coding plans via a `/usage` command and a compact
+A [pi-agent](https://github.com/earendil-works/pi) extension that surfaces
+subscription plan usage / rate limits via a `/usage` command and a compact
 status-line widget.
 
 Credentials are read from pi's auth store, so anything you have logged into with
@@ -14,12 +13,6 @@ Credentials are read from pi's auth store, so anything you have logged into with
 | OpenAI Codex       | `GET https://chatgpt.com/backend-api/wham/usage`             | `openai-codex` OAuth token + ChatGPT account id |
 | GLM Coding         | `GET https://api.z.ai/api/monitor/usage/quota/limit`         | `zai` API key                                   |
 | GLM Coding (China) | `GET https://open.bigmodel.cn/api/monitor/usage/quota/limit` | `zai-coding-cn` API key                         |
-
-Expired access tokens are refreshed transparently through pi's auth storage before
-the usage request is made. The GLM coding plan uses whatever API key pi resolves for
-the `zai` (or `zai-coding-cn`) provider, so `ZAI_API_KEY` / `ZAI_CODING_CN_API_KEY`
-work as well as `/login`. `/usage` reports the platform you have a key for,
-preferring the global one. The widget follows the active model's provider.
 
 ## Install
 
@@ -45,39 +38,14 @@ pi -e ./plugins/usage
 /usage
 ```
 
-Example output:
-
-```text
-Claude
-  Session (5h)           [████░░░░░░]  42% · resets in 2h 13m
-  Week (all models)      [██░░░░░░░░]  17% · resets in 4d 2h
-  Week (Sonnet)          [█░░░░░░░░░]   8% · resets in 4d 2h
-  Extra usage            [██░░░░░░░░]  23% €9.31 of €40.00
-
-OpenAI Codex (pro)
-  5h limit               [████░░░░░░]  42% · resets in 3h 25m
-  Week limit             [████████░░]  84% · resets in 4d 2h
-
-GLM Coding (max)
-  Session (5h)           [█░░░░░░░░░]   7% · resets in 4h 17m · 2,096 of 28,000 credits
-  Week                   [░░░░░░░░░░]   1% · resets in 5d 1h · 2,096 of 140,000 credits
-```
+Prints one section per provider with a progress bar, percentage and reset countdown
+for each rate-limit window.
 
 ## Widget
 
-While the active model belongs to a subscription provider (`anthropic`,
-`openai-codex`, `zai`, or `zai-coding-cn`), the session and weekly rate limits are
-shown as small progress bars on the shared status line above the editor:
-
-```text
-5h ██░░░ 42% (2h) · wk █░░░░ 17% (4d)
-```
-
-The value in parentheses is the time left until that window resets.
-
-The widget refreshes in the background (at most every 30 seconds) when a session
-starts, a model is selected, or an agent turn settles, and reuses the data fetched by
-`/usage`.
+While the active model belongs to one of the providers above, the session and weekly
+rate limits are shown as small progress bars, each with the time left until it
+resets, on the shared status line above the editor.
 
 ## Configuration
 

--- a/plugins/usage/package.json
+++ b/plugins/usage/package.json
@@ -1,17 +1,20 @@
 {
   "name": "@pi-plugins/usage",
   "version": "0.4.1",
-  "description": "Subscription usage/rate-limit command extension for pi-agent (Claude and OpenAI Codex plans).",
+  "description": "Subscription usage/rate-limit command extension for pi-agent (Claude, OpenAI Codex, and GLM coding plans).",
   "keywords": [
     "anthropic",
     "codex",
+    "glm",
     "openai",
     "pi",
     "pi-agent",
     "pi-extension",
     "pi-package",
     "rate-limit",
-    "usage"
+    "usage",
+    "zai",
+    "zhipu"
   ],
   "homepage": "https://github.com/k3dom/pi-plugins/tree/main/plugins/usage#readme",
   "bugs": {

--- a/plugins/usage/package.json
+++ b/plugins/usage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pi-plugins/usage",
   "version": "0.4.1",
-  "description": "Subscription usage/rate-limit command extension for pi-agent (Claude, OpenAI Codex, and GLM coding plans).",
+  "description": "Subscription usage/rate-limit command extension for pi-agent.",
   "keywords": [
     "anthropic",
     "codex",

--- a/plugins/usage/src/index.ts
+++ b/plugins/usage/src/index.ts
@@ -1,9 +1,9 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
-import { readStoredCredential } from '@earendil-works/pi-coding-agent'
 import { loadExtensionConfig } from '@pi-plugins/shared/config'
 import { runHandler } from '@pi-plugins/shared/run'
 import { setStatuslineSegment } from '@pi-plugins/shared/statusline'
-import { Effect, Schema } from 'effect'
+import { Effect, Record, Schema } from 'effect'
+import { ZAI_BASE_URL, type ZaiProvider } from './provider/zai'
 import {
   claudeSection,
   codexSection,
@@ -27,7 +27,7 @@ const UsageConfig = Schema.Struct({
   showWidget: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
 })
 
-type WidgetProvider = 'claude' | 'codex' | 'glm'
+type WidgetProvider = 'claude' | 'codex' | ZaiProvider
 
 function widgetProvider(
   model: ExtensionContext['model'],
@@ -39,26 +39,10 @@ function widgetProvider(
       return 'codex'
     case 'zai':
     case 'zai-coding-cn':
-      return 'glm'
+      return model.provider
     default:
       return undefined
   }
-}
-
-/** Whether the widget's GLM platform is the Zhipu China one. */
-function widgetGlmCn(ctx: ExtensionContext): boolean {
-  return ctx.model?.provider === 'zai-coding-cn'
-}
-
-/**
- * Which GLM platform `/usage` reports on: the one with a stored API key,
- * preferring the global Z.ai platform when both exist.
- */
-function reportGlmCn(): boolean {
-  if (readStoredCredential('zai')?.type === 'api_key') {
-    return false
-  }
-  return readStoredCredential('zai-coding-cn')?.type === 'api_key'
 }
 
 function section<A>(
@@ -124,7 +108,7 @@ export default function usage(pi: ExtensionAPI): void {
         ? claudeWidgetLimits(yield* service.claude())
         : provider === 'codex'
           ? codexWidgetLimits(yield* service.codex(), new Date())
-          : glmWidgetLimits(yield* service.glm(widgetGlmCn(ctx)))
+          : glmWidgetLimits(yield* service.glm(provider))
     }).pipe(Effect.provide(UsageService.layer(ctx.modelRegistry)))
 
     let limits: WidgetLimit[] | undefined
@@ -161,6 +145,11 @@ export default function usage(pi: ExtensionAPI): void {
       'Show subscription usage/rate limits for Claude, OpenAI Codex, and GLM coding plans',
     handler: async (_args, ctx) => {
       const now = new Date()
+      // The GLM platforms are separate accounts; the global one wins when both have a key.
+      const glmProvider =
+        Record.keys(ZAI_BASE_URL).find(
+          (id) => ctx.modelRegistry.getProviderAuthStatus(id).configured,
+        ) ?? 'zai'
       const program = Effect.gen(function* () {
         const service = yield* UsageService
         const sections = yield* Effect.all(
@@ -194,10 +183,12 @@ export default function usage(pi: ExtensionAPI): void {
             section(
               'GLM Coding',
               service
-                .glm(reportGlmCn())
+                .glm(glmProvider)
                 .pipe(
                   Effect.tap((data) =>
-                    Effect.sync(() => recordLimits('glm', glmWidgetLimits(data))),
+                    Effect.sync(() =>
+                      recordLimits(glmProvider, glmWidgetLimits(data)),
+                    ),
                   ),
                 ),
               glmSection,

--- a/plugins/usage/src/index.ts
+++ b/plugins/usage/src/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
+import { readStoredCredential } from '@earendil-works/pi-coding-agent'
 import { loadExtensionConfig } from '@pi-plugins/shared/config'
 import { runHandler } from '@pi-plugins/shared/run'
 import { setStatuslineSegment } from '@pi-plugins/shared/statusline'
@@ -6,6 +7,7 @@ import { Effect, Schema } from 'effect'
 import {
   claudeSection,
   codexSection,
+  glmSection,
   renderSections,
   type UsageSection,
 } from './render'
@@ -13,6 +15,7 @@ import { UsageService, type UsageServiceError } from './service'
 import {
   claudeWidgetLimits,
   codexWidgetLimits,
+  glmWidgetLimits,
   widgetText,
   type WidgetLimit,
 } from './widget'
@@ -24,7 +27,7 @@ const UsageConfig = Schema.Struct({
   showWidget: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
 })
 
-type WidgetProvider = 'claude' | 'codex'
+type WidgetProvider = 'claude' | 'codex' | 'glm'
 
 function widgetProvider(
   model: ExtensionContext['model'],
@@ -34,9 +37,28 @@ function widgetProvider(
       return 'claude'
     case 'openai-codex':
       return 'codex'
+    case 'zai':
+    case 'zai-coding-cn':
+      return 'glm'
     default:
       return undefined
   }
+}
+
+/** Whether the widget's GLM platform is the Zhipu China one. */
+function widgetGlmCn(ctx: ExtensionContext): boolean {
+  return ctx.model?.provider === 'zai-coding-cn'
+}
+
+/**
+ * Which GLM platform `/usage` reports on: the one with a stored API key,
+ * preferring the global Z.ai platform when both exist.
+ */
+function reportGlmCn(): boolean {
+  if (readStoredCredential('zai')?.type === 'api_key') {
+    return false
+  }
+  return readStoredCredential('zai-coding-cn')?.type === 'api_key'
 }
 
 function section<A>(
@@ -100,7 +122,9 @@ export default function usage(pi: ExtensionAPI): void {
       const service = yield* UsageService
       return provider === 'claude'
         ? claudeWidgetLimits(yield* service.claude())
-        : codexWidgetLimits(yield* service.codex(), new Date())
+        : provider === 'codex'
+          ? codexWidgetLimits(yield* service.codex(), new Date())
+          : glmWidgetLimits(yield* service.glm(widgetGlmCn(ctx)))
     }).pipe(Effect.provide(UsageService.layer(ctx.modelRegistry)))
 
     let limits: WidgetLimit[] | undefined
@@ -134,7 +158,7 @@ export default function usage(pi: ExtensionAPI): void {
 
   pi.registerCommand('usage', {
     description:
-      'Show subscription usage/rate limits for Claude and OpenAI Codex plans',
+      'Show subscription usage/rate limits for Claude, OpenAI Codex, and GLM coding plans',
     handler: async (_args, ctx) => {
       const now = new Date()
       const program = Effect.gen(function* () {
@@ -166,6 +190,17 @@ export default function usage(pi: ExtensionAPI): void {
                   ),
                 ),
               (data) => codexSection(data, now),
+            ),
+            section(
+              'GLM Coding',
+              service
+                .glm(reportGlmCn())
+                .pipe(
+                  Effect.tap((data) =>
+                    Effect.sync(() => recordLimits('glm', glmWidgetLimits(data))),
+                  ),
+                ),
+              glmSection,
             ),
           ],
           { concurrency: 'unbounded' },

--- a/plugins/usage/src/index.ts
+++ b/plugins/usage/src/index.ts
@@ -145,7 +145,6 @@ export default function usage(pi: ExtensionAPI): void {
       'Show subscription usage/rate limits for Claude, OpenAI Codex, and GLM coding plans',
     handler: async (_args, ctx) => {
       const now = new Date()
-      // The GLM platforms are separate accounts; the global one wins when both have a key.
       const glmProvider =
         Record.keys(ZAI_BASE_URL).find(
           (id) => ctx.modelRegistry.getProviderAuthStatus(id).configured,

--- a/plugins/usage/src/index.ts
+++ b/plugins/usage/src/index.ts
@@ -141,8 +141,7 @@ export default function usage(pi: ExtensionAPI): void {
   })
 
   pi.registerCommand('usage', {
-    description:
-      'Show subscription usage/rate limits for Claude, OpenAI Codex, and GLM coding plans',
+    description: 'Show subscription plan usage and rate limits',
     handler: async (_args, ctx) => {
       const now = new Date()
       const glmProvider =

--- a/plugins/usage/src/provider/zai.ts
+++ b/plugins/usage/src/provider/zai.ts
@@ -1,0 +1,101 @@
+import { Schema as S } from 'effect'
+import { HttpApi, HttpApiEndpoint, HttpApiGroup } from 'effect/unstable/httpapi'
+
+/**
+ * Model of the GLM Coding Plan usage endpoint (Z.ai global / Zhipu China).
+ * Undocumented console API the official usage dashboard calls:
+ *
+ *   GET https://api.z.ai/api/monitor/usage/quota/limit
+ *   GET https://open.bigmodel.cn/api/monitor/usage/quota/limit
+ *
+ */
+
+export const ZAI_BASE_URL = 'https://api.z.ai'
+export const ZAI_CN_BASE_URL = 'https://open.bigmodel.cn'
+
+/**
+ * One quota window. `type` depends on plan generation: `TOKENS_LIMIT` (token
+ * plans), `CREDIT_LIMIT` (points plans), `TIME_LIMIT` (monthly MCP tools).
+ */
+export const ZaiQuotaLimit = S.Struct({
+  /** "TOKENS_LIMIT" | "CREDIT_LIMIT" | "TIME_LIMIT" | future values. */
+  type: S.optional(S.NullOr(S.String)),
+  /**
+   * Window duration as unit enum + count: unit 3 (hour) + 5 → 5h window,
+   * unit 6 (week) + 1 → weekly window. Values are inferred, not documented.
+   */
+  unit: S.optional(S.NullOr(S.Number)),
+  number: S.optional(S.NullOr(S.Number)),
+  /** Total quota of the window (tokens or credits). */
+  usage: S.optional(S.NullOr(S.Number)),
+  /** Amount used in the current window. */
+  currentValue: S.optional(S.NullOr(S.Number)),
+  remaining: S.optional(S.NullOr(S.Number)),
+  /** Percentage used, 0-100. */
+  percentage: S.optional(S.NullOr(S.Number)),
+  /** Epoch milliseconds when the window resets. */
+  nextResetTime: S.optional(S.NullOr(S.Number)),
+})
+export type ZaiQuotaLimit = typeof ZaiQuotaLimit.Type
+
+export const ZaiUsageData = S.Struct({
+  limits: S.optional(S.NullOr(S.Array(ZaiQuotaLimit))),
+  /** Plan tier, e.g. "lite" | "pro" | "max". */
+  level: S.optional(S.NullOr(S.String)),
+})
+export type ZaiUsageData = typeof ZaiUsageData.Type
+
+/**
+ * Every endpoint of the platform returns this envelope with HTTP 200; API
+ * errors are `success: false` / `code !== 200` inside the body.
+ */
+export const ZaiUsageEnvelope = S.Struct({
+  code: S.optional(S.NullOr(S.Number)),
+  msg: S.optional(S.NullOr(S.String)),
+  data: S.optional(S.NullOr(ZaiUsageData)),
+  success: S.optional(S.NullOr(S.Boolean)),
+})
+export type ZaiUsageEnvelope = typeof ZaiUsageEnvelope.Type
+
+export const ZaiUsageApi = HttpApi.make('ZaiUsage').add(
+  HttpApiGroup.make('monitor', { topLevel: true }).add(
+    HttpApiEndpoint.get('usage', '/api/monitor/usage/quota/limit', {
+      success: ZaiUsageEnvelope,
+    }),
+  ),
+)
+
+/**
+ * Rate-limit windows of the plan (token/credit limits only; the monthly MCP
+ * `TIME_LIMIT` is separate), sorted by `nextResetTime`. The official
+ * dashboard treats the first entry as the 5h window and the second as the
+ * weekly one, since `unit`/`number` are undocumented.
+ */
+export function zaiRateLimits(usage: ZaiUsageData): ZaiQuotaLimit[] {
+  return (usage.limits ?? [])
+    .filter(
+      (limit) => limit.type === 'TOKENS_LIMIT' || limit.type === 'CREDIT_LIMIT',
+    )
+    .toSorted(
+      (a, b) =>
+        (a.nextResetTime ?? Number.POSITIVE_INFINITY) -
+        (b.nextResetTime ?? Number.POSITIVE_INFINITY),
+    )
+}
+
+/** Monthly MCP tools quota (`TIME_LIMIT`), if the plan reports one. */
+export function zaiMcpLimit(usage: ZaiUsageData): ZaiQuotaLimit | undefined {
+  return (usage.limits ?? []).find((limit) => limit.type === 'TIME_LIMIT')
+}
+
+/** Unit word for the quota counters, by plan generation. */
+export function zaiUnitWord(limit: ZaiQuotaLimit): string {
+  switch (limit.type) {
+    case 'CREDIT_LIMIT':
+      return 'credits'
+    case 'TIME_LIMIT':
+      return 'uses'
+    default:
+      return 'tokens'
+  }
+}

--- a/plugins/usage/src/provider/zai.ts
+++ b/plugins/usage/src/provider/zai.ts
@@ -1,77 +1,54 @@
 import { Schema as S } from 'effect'
 import { HttpApi, HttpApiEndpoint, HttpApiGroup } from 'effect/unstable/httpapi'
 
-/**
- * Model of the GLM Coding Plan usage endpoint (Z.ai global / Zhipu China).
- * Undocumented console API the official usage dashboard calls:
- *
- *   GET https://api.z.ai/api/monitor/usage/quota/limit
- *   GET https://open.bigmodel.cn/api/monitor/usage/quota/limit
- *
- */
+/** Console API host of each pi provider (global Z.ai vs. Zhipu China platform). */
+export const ZAI_BASE_URL = {
+  zai: 'https://api.z.ai',
+  'zai-coding-cn': 'https://open.bigmodel.cn',
+} as const
+export type ZaiProvider = keyof typeof ZAI_BASE_URL
 
-export const ZAI_BASE_URL = 'https://api.z.ai'
-export const ZAI_CN_BASE_URL = 'https://open.bigmodel.cn'
-
-/**
- * One quota window. `type` depends on plan generation: `TOKENS_LIMIT` (token
- * plans), `CREDIT_LIMIT` (points plans), `TIME_LIMIT` (monthly MCP tools).
- */
-export const ZaiQuotaLimit = S.Struct({
-  /** "TOKENS_LIMIT" | "CREDIT_LIMIT" | "TIME_LIMIT" | future values. */
+export const QuotaLimit = S.Struct({
+  /** `TOKENS_LIMIT` (token plans), `CREDIT_LIMIT` (credit plans) or `TIME_LIMIT` (monthly MCP tools). */
   type: S.optional(S.NullOr(S.String)),
-  /**
-   * Window duration as unit enum + count: unit 3 (hour) + 5 → 5h window,
-   * unit 6 (week) + 1 → weekly window. Values are inferred, not documented.
-   */
-  unit: S.optional(S.NullOr(S.Number)),
-  number: S.optional(S.NullOr(S.Number)),
-  /** Total quota of the window (tokens or credits). */
+  /** Total quota of the window, despite the name. */
   usage: S.optional(S.NullOr(S.Number)),
-  /** Amount used in the current window. */
   currentValue: S.optional(S.NullOr(S.Number)),
-  remaining: S.optional(S.NullOr(S.Number)),
-  /** Percentage used, 0-100. */
   percentage: S.optional(S.NullOr(S.Number)),
-  /** Epoch milliseconds when the window resets. */
+  /** Epoch milliseconds. */
   nextResetTime: S.optional(S.NullOr(S.Number)),
 })
-export type ZaiQuotaLimit = typeof ZaiQuotaLimit.Type
+export type QuotaLimit = typeof QuotaLimit.Type
 
-export const ZaiUsageData = S.Struct({
-  limits: S.optional(S.NullOr(S.Array(ZaiQuotaLimit))),
-  /** Plan tier, e.g. "lite" | "pro" | "max". */
+export const GlmUsage = S.Struct({
   level: S.optional(S.NullOr(S.String)),
+  limits: S.optional(S.NullOr(S.Array(QuotaLimit))),
 })
-export type ZaiUsageData = typeof ZaiUsageData.Type
+export type GlmUsage = typeof GlmUsage.Type
 
-/**
- * Every endpoint of the platform returns this envelope with HTTP 200; API
- * errors are `success: false` / `code !== 200` inside the body.
- */
-export const ZaiUsageEnvelope = S.Struct({
+/** API errors arrive as HTTP 200 with the failure inside this envelope. */
+export const GlmUsageEnvelope = S.Struct({
   code: S.optional(S.NullOr(S.Number)),
   msg: S.optional(S.NullOr(S.String)),
-  data: S.optional(S.NullOr(ZaiUsageData)),
   success: S.optional(S.NullOr(S.Boolean)),
+  data: S.optional(S.NullOr(GlmUsage)),
 })
-export type ZaiUsageEnvelope = typeof ZaiUsageEnvelope.Type
+export type GlmUsageEnvelope = typeof GlmUsageEnvelope.Type
 
-export const ZaiUsageApi = HttpApi.make('ZaiUsage').add(
+export const GlmUsageApi = HttpApi.make('GlmUsage').add(
   HttpApiGroup.make('monitor', { topLevel: true }).add(
     HttpApiEndpoint.get('usage', '/api/monitor/usage/quota/limit', {
-      success: ZaiUsageEnvelope,
+      success: GlmUsageEnvelope,
     }),
   ),
 )
 
 /**
- * Rate-limit windows of the plan (token/credit limits only; the monthly MCP
- * `TIME_LIMIT` is separate), sorted by `nextResetTime`. The official
- * dashboard treats the first entry as the 5h window and the second as the
- * weekly one, since `unit`/`number` are undocumented.
+ * The token/credit windows in reset order. Nothing in the payload names a
+ * window, so like the official dashboard the first is taken as the 5h window
+ * and the second as the weekly one.
  */
-export function zaiRateLimits(usage: ZaiUsageData): ZaiQuotaLimit[] {
+export function glmRateLimits(usage: GlmUsage): QuotaLimit[] {
   return (usage.limits ?? [])
     .filter(
       (limit) => limit.type === 'TOKENS_LIMIT' || limit.type === 'CREDIT_LIMIT',
@@ -81,21 +58,4 @@ export function zaiRateLimits(usage: ZaiUsageData): ZaiQuotaLimit[] {
         (a.nextResetTime ?? Number.POSITIVE_INFINITY) -
         (b.nextResetTime ?? Number.POSITIVE_INFINITY),
     )
-}
-
-/** Monthly MCP tools quota (`TIME_LIMIT`), if the plan reports one. */
-export function zaiMcpLimit(usage: ZaiUsageData): ZaiQuotaLimit | undefined {
-  return (usage.limits ?? []).find((limit) => limit.type === 'TIME_LIMIT')
-}
-
-/** Unit word for the quota counters, by plan generation. */
-export function zaiUnitWord(limit: ZaiQuotaLimit): string {
-  switch (limit.type) {
-    case 'CREDIT_LIMIT':
-      return 'credits'
-    case 'TIME_LIMIT':
-      return 'uses'
-    default:
-      return 'tokens'
-  }
 }

--- a/plugins/usage/src/provider/zai.ts
+++ b/plugins/usage/src/provider/zai.ts
@@ -1,7 +1,6 @@
-import { Schema as S } from 'effect'
+import { Array, Order, pipe, Schema as S } from 'effect'
 import { HttpApi, HttpApiEndpoint, HttpApiGroup } from 'effect/unstable/httpapi'
 
-/** Console API host of each pi provider (global Z.ai vs. Zhipu China platform). */
 export const ZAI_BASE_URL = {
   zai: 'https://api.z.ai',
   'zai-coding-cn': 'https://open.bigmodel.cn',
@@ -9,14 +8,12 @@ export const ZAI_BASE_URL = {
 export type ZaiProvider = keyof typeof ZAI_BASE_URL
 
 export const QuotaLimit = S.Struct({
-  /** `TOKENS_LIMIT` (token plans), `CREDIT_LIMIT` (credit plans) or `TIME_LIMIT` (monthly MCP tools). */
   type: S.optional(S.NullOr(S.String)),
   /** Total quota of the window, despite the name. */
   usage: S.optional(S.NullOr(S.Number)),
   currentValue: S.optional(S.NullOr(S.Number)),
   percentage: S.optional(S.NullOr(S.Number)),
-  /** Epoch milliseconds. */
-  nextResetTime: S.optional(S.NullOr(S.Number)),
+  nextResetTime: S.optional(S.NullOr(S.DateFromMillis)),
 })
 export type QuotaLimit = typeof QuotaLimit.Type
 
@@ -26,13 +23,14 @@ export const GlmUsage = S.Struct({
 })
 export type GlmUsage = typeof GlmUsage.Type
 
-/** API errors arrive as HTTP 200 with the failure inside this envelope. */
-export const GlmUsageEnvelope = S.Struct({
-  code: S.optional(S.NullOr(S.Number)),
-  msg: S.optional(S.NullOr(S.String)),
-  success: S.optional(S.NullOr(S.Boolean)),
-  data: S.optional(S.NullOr(GlmUsage)),
-})
+export const GlmUsageEnvelope = S.Union([
+  S.Struct({ success: S.Literal(true), data: GlmUsage }),
+  S.Struct({
+    success: S.Literal(false),
+    code: S.Number,
+    msg: S.optional(S.NullOr(S.String)),
+  }),
+])
 export type GlmUsageEnvelope = typeof GlmUsageEnvelope.Type
 
 export const GlmUsageApi = HttpApi.make('GlmUsage').add(
@@ -43,19 +41,16 @@ export const GlmUsageApi = HttpApi.make('GlmUsage').add(
   ),
 )
 
-/**
- * The token/credit windows in reset order. Nothing in the payload names a
- * window, so like the official dashboard the first is taken as the 5h window
- * and the second as the weekly one.
- */
+/** Nothing names a window, so like the official dashboard: first reset = 5h, second = weekly. */
 export function glmRateLimits(usage: GlmUsage): QuotaLimit[] {
-  return (usage.limits ?? [])
-    .filter(
+  return pipe(
+    usage.limits ?? [],
+    Array.filter(
       (limit) => limit.type === 'TOKENS_LIMIT' || limit.type === 'CREDIT_LIMIT',
-    )
-    .toSorted(
-      (a, b) =>
-        (a.nextResetTime ?? Number.POSITIVE_INFINITY) -
-        (b.nextResetTime ?? Number.POSITIVE_INFINITY),
-    )
+    ),
+    Array.sortWith(
+      (limit) => limit.nextResetTime?.getTime() ?? Number.POSITIVE_INFINITY,
+      Order.Number,
+    ),
+  )
 }

--- a/plugins/usage/src/render.ts
+++ b/plugins/usage/src/render.ts
@@ -1,6 +1,13 @@
 import type { ClaudeUsage, UnifiedLimit, UsageWindow } from './provider/anthropic'
 import type { CodexUsage, RateLimitDetails } from './provider/openai'
-import { codexResetsAt, formatDuration, parseResetsAt } from './reset'
+import {
+  zaiMcpLimit,
+  zaiRateLimits,
+  zaiUnitWord,
+  type ZaiQuotaLimit,
+  type ZaiUsageData,
+} from './provider/zai'
+import { codexResetsAt, formatDuration, parseEpochMs, parseResetsAt } from './reset'
 
 const MIN_LABEL_WIDTH = 22
 const BAR_WIDTH = 10
@@ -232,5 +239,48 @@ export function codexSection(usage: CodexUsage, now: Date): UsageSection {
   const title = usage.plan_type
     ? `OpenAI Codex (${usage.plan_type})`
     : 'OpenAI Codex'
+  return { title, rows }
+}
+
+// ─── GLM Coding Plan ──────────────────────────────────────────────────────────
+
+const numberFormat = new Intl.NumberFormat('en-US')
+
+/** Quota note like "1,360 of 28,000 credits", when the counts are known. */
+function zaiQuotaNote(current: number, total: number, unitWord: string): string {
+  return `${numberFormat.format(current)} of ${numberFormat.format(total)} ${unitWord}`
+}
+
+function zaiLimitRow(label: string, limit: ZaiQuotaLimit): UsageRow {
+  const current = typeof limit.currentValue === 'number' ? limit.currentValue : null
+  const total = typeof limit.usage === 'number' ? limit.usage : null
+  return {
+    label,
+    percent: limit.percentage,
+    resetsAt: parseEpochMs(limit.nextResetTime),
+    note:
+      current !== null && total !== null && total > 0
+        ? zaiQuotaNote(current, total, zaiUnitWord(limit))
+        : undefined,
+  }
+}
+
+export function glmSection(usage: ZaiUsageData): UsageSection {
+  const rows: UsageRow[] = []
+
+  // Sorted by reset time: first entry is the 5h window, second the weekly one
+  // (the official dashboard's convention; `unit`/`number` are undocumented).
+  for (const [index, limit] of zaiRateLimits(usage).entries()) {
+    const label =
+      index === 0 ? 'Session (5h)' : index === 1 ? 'Week' : `Window ${index + 1}`
+    rows.push(zaiLimitRow(label, limit))
+  }
+
+  const mcp = zaiMcpLimit(usage)
+  if (mcp) {
+    rows.push(zaiLimitRow('MCP tools (month)', mcp))
+  }
+
+  const title = usage.level ? `GLM Coding (${usage.level})` : 'GLM Coding'
   return { title, rows }
 }

--- a/plugins/usage/src/render.ts
+++ b/plugins/usage/src/render.ts
@@ -1,7 +1,8 @@
+import { Array } from 'effect'
 import type { ClaudeUsage, UnifiedLimit, UsageWindow } from './provider/anthropic'
 import type { CodexUsage, RateLimitDetails } from './provider/openai'
 import { glmRateLimits, type GlmUsage, type QuotaLimit } from './provider/zai'
-import { codexResetsAt, formatDuration, glmResetsAt, parseResetsAt } from './reset'
+import { codexResetsAt, formatDuration, parseResetsAt } from './reset'
 
 const MIN_LABEL_WIDTH = 22
 const BAR_WIDTH = 10
@@ -247,7 +248,7 @@ function glmRow(label: string, limit: QuotaLimit): UsageRow {
   return {
     label,
     percent: limit.percentage,
-    resetsAt: glmResetsAt(limit),
+    resetsAt: limit.nextResetTime,
     note:
       typeof limit.currentValue === 'number' &&
       typeof limit.usage === 'number' &&
@@ -258,12 +259,7 @@ function glmRow(label: string, limit: QuotaLimit): UsageRow {
 }
 
 export function glmSection(usage: GlmUsage): UsageSection {
-  const rows = glmRateLimits(usage).map((limit, index) =>
-    glmRow(
-      index === 0 ? 'Session (5h)' : index === 1 ? 'Week' : `Window ${index + 1}`,
-      limit,
-    ),
-  )
+  const rows = Array.zipWith(['Session (5h)', 'Week'], glmRateLimits(usage), glmRow)
 
   const mcp = usage.limits?.find((limit) => limit.type === 'TIME_LIMIT')
   if (mcp) {

--- a/plugins/usage/src/render.ts
+++ b/plugins/usage/src/render.ts
@@ -1,16 +1,11 @@
 import type { ClaudeUsage, UnifiedLimit, UsageWindow } from './provider/anthropic'
 import type { CodexUsage, RateLimitDetails } from './provider/openai'
-import {
-  zaiMcpLimit,
-  zaiRateLimits,
-  zaiUnitWord,
-  type ZaiQuotaLimit,
-  type ZaiUsageData,
-} from './provider/zai'
-import { codexResetsAt, formatDuration, parseEpochMs, parseResetsAt } from './reset'
+import { glmRateLimits, type GlmUsage, type QuotaLimit } from './provider/zai'
+import { codexResetsAt, formatDuration, glmResetsAt, parseResetsAt } from './reset'
 
 const MIN_LABEL_WIDTH = 22
 const BAR_WIDTH = 10
+const numberFormat = new Intl.NumberFormat('en-US')
 
 export interface UsageRow {
   readonly label: string
@@ -242,43 +237,37 @@ export function codexSection(usage: CodexUsage, now: Date): UsageSection {
   return { title, rows }
 }
 
-// ─── GLM Coding Plan ──────────────────────────────────────────────────────────
-
-const numberFormat = new Intl.NumberFormat('en-US')
-
-/** Quota note like "1,360 of 28,000 credits", when the counts are known. */
-function zaiQuotaNote(current: number, total: number, unitWord: string): string {
-  return `${numberFormat.format(current)} of ${numberFormat.format(total)} ${unitWord}`
-}
-
-function zaiLimitRow(label: string, limit: ZaiQuotaLimit): UsageRow {
-  const current = typeof limit.currentValue === 'number' ? limit.currentValue : null
-  const total = typeof limit.usage === 'number' ? limit.usage : null
+function glmRow(label: string, limit: QuotaLimit): UsageRow {
+  const unit =
+    limit.type === 'CREDIT_LIMIT'
+      ? 'credits'
+      : limit.type === 'TIME_LIMIT'
+        ? 'calls'
+        : 'tokens'
   return {
     label,
     percent: limit.percentage,
-    resetsAt: parseEpochMs(limit.nextResetTime),
+    resetsAt: glmResetsAt(limit),
     note:
-      current !== null && total !== null && total > 0
-        ? zaiQuotaNote(current, total, zaiUnitWord(limit))
+      typeof limit.currentValue === 'number' &&
+      typeof limit.usage === 'number' &&
+      limit.usage > 0
+        ? `${numberFormat.format(limit.currentValue)} of ${numberFormat.format(limit.usage)} ${unit}`
         : undefined,
   }
 }
 
-export function glmSection(usage: ZaiUsageData): UsageSection {
-  const rows: UsageRow[] = []
+export function glmSection(usage: GlmUsage): UsageSection {
+  const rows = glmRateLimits(usage).map((limit, index) =>
+    glmRow(
+      index === 0 ? 'Session (5h)' : index === 1 ? 'Week' : `Window ${index + 1}`,
+      limit,
+    ),
+  )
 
-  // Sorted by reset time: first entry is the 5h window, second the weekly one
-  // (the official dashboard's convention; `unit`/`number` are undocumented).
-  for (const [index, limit] of zaiRateLimits(usage).entries()) {
-    const label =
-      index === 0 ? 'Session (5h)' : index === 1 ? 'Week' : `Window ${index + 1}`
-    rows.push(zaiLimitRow(label, limit))
-  }
-
-  const mcp = zaiMcpLimit(usage)
+  const mcp = usage.limits?.find((limit) => limit.type === 'TIME_LIMIT')
   if (mcp) {
-    rows.push(zaiLimitRow('MCP tools (month)', mcp))
+    rows.push(glmRow('MCP tools (month)', mcp))
   }
 
   const title = usage.level ? `GLM Coding (${usage.level})` : 'GLM Coding'

--- a/plugins/usage/src/reset.ts
+++ b/plugins/usage/src/reset.ts
@@ -1,5 +1,4 @@
 import type { RateLimitWindow } from './provider/openai'
-import type { QuotaLimit } from './provider/zai'
 
 export function parseResetsAt(
   value: string | number | null | undefined,
@@ -23,13 +22,6 @@ export function codexResetsAt(window: RateLimitWindow, now: Date): Date | null {
     return new Date(window.reset_at * 1000)
   }
   return null
-}
-
-export function glmResetsAt(limit: QuotaLimit): Date | null {
-  return typeof limit.nextResetTime === 'number' &&
-    Number.isFinite(limit.nextResetTime)
-    ? new Date(limit.nextResetTime)
-    : null
 }
 
 export function formatDuration(ms: number): string {

--- a/plugins/usage/src/reset.ts
+++ b/plugins/usage/src/reset.ts
@@ -14,6 +14,10 @@ export function parseResetsAt(
   return null
 }
 
+export function parseEpochMs(value: number | null | undefined): Date | null {
+  return typeof value === 'number' && !Number.isNaN(value) ? new Date(value) : null
+}
+
 export function codexResetsAt(window: RateLimitWindow, now: Date): Date | null {
   if (typeof window.reset_after_seconds === 'number') {
     return new Date(now.getTime() + window.reset_after_seconds * 1000)

--- a/plugins/usage/src/reset.ts
+++ b/plugins/usage/src/reset.ts
@@ -1,4 +1,5 @@
 import type { RateLimitWindow } from './provider/openai'
+import type { QuotaLimit } from './provider/zai'
 
 export function parseResetsAt(
   value: string | number | null | undefined,
@@ -14,10 +15,6 @@ export function parseResetsAt(
   return null
 }
 
-export function parseEpochMs(value: number | null | undefined): Date | null {
-  return typeof value === 'number' && !Number.isNaN(value) ? new Date(value) : null
-}
-
 export function codexResetsAt(window: RateLimitWindow, now: Date): Date | null {
   if (typeof window.reset_after_seconds === 'number') {
     return new Date(now.getTime() + window.reset_after_seconds * 1000)
@@ -26,6 +23,13 @@ export function codexResetsAt(window: RateLimitWindow, now: Date): Date | null {
     return new Date(window.reset_at * 1000)
   }
   return null
+}
+
+export function glmResetsAt(limit: QuotaLimit): Date | null {
+  return typeof limit.nextResetTime === 'number' &&
+    Number.isFinite(limit.nextResetTime)
+    ? new Date(limit.nextResetTime)
+    : null
 }
 
 export function formatDuration(ms: number): string {

--- a/plugins/usage/src/service.ts
+++ b/plugins/usage/src/service.ts
@@ -24,7 +24,7 @@ import {
   ClaudeUsageApi,
 } from './provider/anthropic'
 import { CHATGPT_BASE_URL, CodexUsageApi } from './provider/openai'
-import { ZAI_BASE_URL, ZAI_CN_BASE_URL, ZaiUsageApi } from './provider/zai'
+import { GlmUsageApi, ZAI_BASE_URL, type ZaiProvider } from './provider/zai'
 
 const REQUEST_TIMEOUT = '10 seconds'
 const LOGIN_HINT = 'run /login to (re-)authenticate'
@@ -59,15 +59,12 @@ const requestFailed = (cause: unknown) =>
 export type UsageProvider = Data.TaggedEnum<{
   Anthropic: {}
   OpenAI: {}
-  /** `cn` selects the Zhipu China platform (open.bigmodel.cn) over Z.ai. */
-  Zai: { readonly cn: boolean }
 }>
 export const UsageProvider = Data.taggedEnum<UsageProvider>()
 
 export type UsageCredentials = Data.TaggedEnum<{
   Anthropic: { readonly accessToken: string }
   OpenAI: { readonly accessToken: string; readonly accountId: string }
-  Zai: { readonly apiKey: string }
 }>
 export const UsageCredentials = Data.taggedEnum<UsageCredentials>()
 
@@ -118,18 +115,12 @@ export class UsageService extends Context.Service<UsageService>()(
         const providerId = UsageProvider.$match(provider, {
           Anthropic: () => 'anthropic',
           OpenAI: () => 'openai-codex',
-          Zai: (zai) => (zai.cn ? 'zai-coding-cn' : 'zai'),
         })
-        // Subscription plans use OAuth; the GLM coding plan uses an API key.
-        const requiredType = provider._tag === 'Zai' ? 'api_key' : 'oauth'
 
-        if (readStoredCredential(providerId)?.type !== requiredType) {
+        if (readStoredCredential(providerId)?.type !== 'oauth') {
           return yield* new UsageServiceError({
             kind: 'CredentialsMissing',
-            message:
-              provider._tag === 'Zai'
-                ? `no API key found for ${providerId} — ${LOGIN_HINT}`
-                : `no subscription (OAuth) credentials found — ${LOGIN_HINT}`,
+            message: `no subscription (OAuth) credentials found — ${LOGIN_HINT}`,
           })
         }
         const accessToken = yield* Effect.tryPromise({
@@ -172,7 +163,6 @@ export class UsageService extends Context.Service<UsageService>()(
             }
             return UsageCredentials.OpenAI({ accessToken, accountId })
           }),
-          Zai: () => Effect.succeed(UsageCredentials.Zai({ apiKey: accessToken })),
         })) as CredentialsFor<P>
       })
 
@@ -212,30 +202,26 @@ export class UsageService extends Context.Service<UsageService>()(
           .pipe(Effect.timeout(REQUEST_TIMEOUT), Effect.mapError(requestFailed))
       })
 
-      const glm = Effect.fn('UsageService.glm')(function* (cn: boolean) {
-        const { apiKey } = yield* credentials(UsageProvider.Zai({ cn }))
-        const client = yield* HttpApiClient.makeWith(ZaiUsageApi, {
-          baseUrl: cn ? ZAI_CN_BASE_URL : ZAI_BASE_URL,
+      const glm = Effect.fn('UsageService.glm')(function* (providerId: ZaiProvider) {
+        const apiKey = yield* Effect.promise(() =>
+          registry.getApiKeyForProvider(providerId),
+        )
+        if (!apiKey) {
+          return yield* new UsageServiceError({
+            kind: 'CredentialsMissing',
+            message: `no API key found for ${providerId} — ${LOGIN_HINT}`,
+          })
+        }
+        const client = yield* HttpApiClient.makeWith(GlmUsageApi, {
+          baseUrl: ZAI_BASE_URL[providerId],
           httpClient: http.pipe(
-            HttpClient.mapRequest(
-              HttpClientRequest.setHeaders({
-                Authorization: `Bearer ${apiKey}`,
-              }),
-            ),
+            HttpClient.mapRequest(HttpClientRequest.bearerToken(apiKey)),
           ),
         })
-        // The platform answers HTTP 200 for API errors too; success is only
-        // signalled inside the envelope body.
         const envelope = yield* client
           .usage()
           .pipe(Effect.timeout(REQUEST_TIMEOUT), Effect.mapError(requestFailed))
-        if (envelope.success === false || envelope.code === undefined) {
-          return yield* new UsageServiceError({
-            kind: 'RequestFailed',
-            message: envelope.msg || 'GLM usage API reported an error',
-          })
-        }
-        if (envelope.code !== 200) {
+        if (envelope.code !== 200 || envelope.success === false) {
           return yield* new UsageServiceError({
             kind: 'RequestFailed',
             message: envelope.msg || `GLM usage API error (code ${envelope.code})`,

--- a/plugins/usage/src/service.ts
+++ b/plugins/usage/src/service.ts
@@ -59,12 +59,14 @@ const requestFailed = (cause: unknown) =>
 export type UsageProvider = Data.TaggedEnum<{
   Anthropic: {}
   OpenAI: {}
+  Zai: { readonly providerId: ZaiProvider }
 }>
 export const UsageProvider = Data.taggedEnum<UsageProvider>()
 
 export type UsageCredentials = Data.TaggedEnum<{
   Anthropic: { readonly accessToken: string }
   OpenAI: { readonly accessToken: string; readonly accountId: string }
+  Zai: { readonly apiKey: string }
 }>
 export const UsageCredentials = Data.taggedEnum<UsageCredentials>()
 
@@ -115,9 +117,11 @@ export class UsageService extends Context.Service<UsageService>()(
         const providerId = UsageProvider.$match(provider, {
           Anthropic: () => 'anthropic',
           OpenAI: () => 'openai-codex',
+          Zai: (zai) => zai.providerId,
         })
+        const oauth = provider._tag !== 'Zai'
 
-        if (readStoredCredential(providerId)?.type !== 'oauth') {
+        if (oauth && readStoredCredential(providerId)?.type !== 'oauth') {
           return yield* new UsageServiceError({
             kind: 'CredentialsMissing',
             message: `no subscription (OAuth) credentials found — ${LOGIN_HINT}`,
@@ -133,10 +137,17 @@ export class UsageService extends Context.Service<UsageService>()(
             }),
         })
         if (!accessToken) {
-          return yield* new UsageServiceError({
-            kind: 'TokenRefreshFailed',
-            message: `token refresh failed — ${LOGIN_HINT}`,
-          })
+          return yield* new UsageServiceError(
+            oauth
+              ? {
+                  kind: 'TokenRefreshFailed',
+                  message: `token refresh failed — ${LOGIN_HINT}`,
+                }
+              : {
+                  kind: 'CredentialsMissing',
+                  message: `no API key found for ${providerId} — ${LOGIN_HINT}`,
+                },
+          )
         }
 
         return (yield* UsageProvider.$match(provider, {
@@ -163,6 +174,7 @@ export class UsageService extends Context.Service<UsageService>()(
             }
             return UsageCredentials.OpenAI({ accessToken, accountId })
           }),
+          Zai: () => Effect.succeed(UsageCredentials.Zai({ apiKey: accessToken })),
         })) as CredentialsFor<P>
       })
 
@@ -203,15 +215,7 @@ export class UsageService extends Context.Service<UsageService>()(
       })
 
       const glm = Effect.fn('UsageService.glm')(function* (providerId: ZaiProvider) {
-        const apiKey = yield* Effect.promise(() =>
-          registry.getApiKeyForProvider(providerId),
-        )
-        if (!apiKey) {
-          return yield* new UsageServiceError({
-            kind: 'CredentialsMissing',
-            message: `no API key found for ${providerId} — ${LOGIN_HINT}`,
-          })
-        }
+        const { apiKey } = yield* credentials(UsageProvider.Zai({ providerId }))
         const client = yield* HttpApiClient.makeWith(GlmUsageApi, {
           baseUrl: ZAI_BASE_URL[providerId],
           httpClient: http.pipe(
@@ -221,13 +225,14 @@ export class UsageService extends Context.Service<UsageService>()(
         const envelope = yield* client
           .usage()
           .pipe(Effect.timeout(REQUEST_TIMEOUT), Effect.mapError(requestFailed))
-        if (envelope.code !== 200 || envelope.success === false) {
+        // The API answers HTTP 200 for failures too, so filterStatusOk can't catch them.
+        if (!envelope.success) {
           return yield* new UsageServiceError({
             kind: 'RequestFailed',
             message: envelope.msg || `GLM usage API error (code ${envelope.code})`,
           })
         }
-        return envelope.data ?? {}
+        return envelope.data
       })
 
       return { claude, codex, glm } as const

--- a/plugins/usage/src/service.ts
+++ b/plugins/usage/src/service.ts
@@ -24,6 +24,7 @@ import {
   ClaudeUsageApi,
 } from './provider/anthropic'
 import { CHATGPT_BASE_URL, CodexUsageApi } from './provider/openai'
+import { ZAI_BASE_URL, ZAI_CN_BASE_URL, ZaiUsageApi } from './provider/zai'
 
 const REQUEST_TIMEOUT = '10 seconds'
 const LOGIN_HINT = 'run /login to (re-)authenticate'
@@ -58,12 +59,15 @@ const requestFailed = (cause: unknown) =>
 export type UsageProvider = Data.TaggedEnum<{
   Anthropic: {}
   OpenAI: {}
+  /** `cn` selects the Zhipu China platform (open.bigmodel.cn) over Z.ai. */
+  Zai: { readonly cn: boolean }
 }>
 export const UsageProvider = Data.taggedEnum<UsageProvider>()
 
 export type UsageCredentials = Data.TaggedEnum<{
   Anthropic: { readonly accessToken: string }
   OpenAI: { readonly accessToken: string; readonly accountId: string }
+  Zai: { readonly apiKey: string }
 }>
 export const UsageCredentials = Data.taggedEnum<UsageCredentials>()
 
@@ -114,12 +118,18 @@ export class UsageService extends Context.Service<UsageService>()(
         const providerId = UsageProvider.$match(provider, {
           Anthropic: () => 'anthropic',
           OpenAI: () => 'openai-codex',
+          Zai: (zai) => (zai.cn ? 'zai-coding-cn' : 'zai'),
         })
+        // Subscription plans use OAuth; the GLM coding plan uses an API key.
+        const requiredType = provider._tag === 'Zai' ? 'api_key' : 'oauth'
 
-        if (readStoredCredential(providerId)?.type !== 'oauth') {
+        if (readStoredCredential(providerId)?.type !== requiredType) {
           return yield* new UsageServiceError({
             kind: 'CredentialsMissing',
-            message: `no subscription (OAuth) credentials found — ${LOGIN_HINT}`,
+            message:
+              provider._tag === 'Zai'
+                ? `no API key found for ${providerId} — ${LOGIN_HINT}`
+                : `no subscription (OAuth) credentials found — ${LOGIN_HINT}`,
           })
         }
         const accessToken = yield* Effect.tryPromise({
@@ -162,6 +172,7 @@ export class UsageService extends Context.Service<UsageService>()(
             }
             return UsageCredentials.OpenAI({ accessToken, accountId })
           }),
+          Zai: () => Effect.succeed(UsageCredentials.Zai({ apiKey: accessToken })),
         })) as CredentialsFor<P>
       })
 
@@ -201,7 +212,39 @@ export class UsageService extends Context.Service<UsageService>()(
           .pipe(Effect.timeout(REQUEST_TIMEOUT), Effect.mapError(requestFailed))
       })
 
-      return { claude, codex } as const
+      const glm = Effect.fn('UsageService.glm')(function* (cn: boolean) {
+        const { apiKey } = yield* credentials(UsageProvider.Zai({ cn }))
+        const client = yield* HttpApiClient.makeWith(ZaiUsageApi, {
+          baseUrl: cn ? ZAI_CN_BASE_URL : ZAI_BASE_URL,
+          httpClient: http.pipe(
+            HttpClient.mapRequest(
+              HttpClientRequest.setHeaders({
+                Authorization: `Bearer ${apiKey}`,
+              }),
+            ),
+          ),
+        })
+        // The platform answers HTTP 200 for API errors too; success is only
+        // signalled inside the envelope body.
+        const envelope = yield* client
+          .usage()
+          .pipe(Effect.timeout(REQUEST_TIMEOUT), Effect.mapError(requestFailed))
+        if (envelope.success === false || envelope.code === undefined) {
+          return yield* new UsageServiceError({
+            kind: 'RequestFailed',
+            message: envelope.msg || 'GLM usage API reported an error',
+          })
+        }
+        if (envelope.code !== 200) {
+          return yield* new UsageServiceError({
+            kind: 'RequestFailed',
+            message: envelope.msg || `GLM usage API error (code ${envelope.code})`,
+          })
+        }
+        return envelope.data ?? {}
+      })
+
+      return { claude, codex, glm } as const
     }),
   },
 ) {

--- a/plugins/usage/src/widget.ts
+++ b/plugins/usage/src/widget.ts
@@ -1,10 +1,10 @@
 import type { ClaudeUsage, UsageWindow } from './provider/anthropic'
 import type { CodexUsage } from './provider/openai'
-import { zaiRateLimits, type ZaiUsageData } from './provider/zai'
+import { glmRateLimits, type GlmUsage } from './provider/zai'
 import {
   codexResetsAt,
   formatCompactDuration,
-  parseEpochMs,
+  glmResetsAt,
   parseResetsAt,
 } from './reset'
 
@@ -105,23 +105,12 @@ export function codexWidgetLimits(usage: CodexUsage, now: Date): WidgetLimit[] {
   )
 }
 
-// ─── GLM Coding Plan ──────────────────────────────────────────────────────────
-
-/** Short label by position after the reset-time sort: first = 5h, second = week. */
-function glmLimitLabel(index: number): string {
-  return index === 0 ? '5h' : index === 1 ? 'wk' : `${index + 1}`
-}
-
-export function glmWidgetLimits(usage: ZaiUsageData): WidgetLimit[] {
-  return zaiRateLimits(usage).flatMap((limit, index) =>
-    typeof limit.percentage === 'number'
-      ? [
-          {
-            label: glmLimitLabel(index),
-            percent: limit.percentage,
-            resetsAt: parseEpochMs(limit.nextResetTime),
-          },
-        ]
-      : [],
-  )
+export function glmWidgetLimits(usage: GlmUsage): WidgetLimit[] {
+  const labels = ['5h', 'wk']
+  return glmRateLimits(usage).flatMap((limit, index) => {
+    const label = labels[index]
+    return label !== undefined && typeof limit.percentage === 'number'
+      ? [{ label, percent: limit.percentage, resetsAt: glmResetsAt(limit) }]
+      : []
+  })
 }

--- a/plugins/usage/src/widget.ts
+++ b/plugins/usage/src/widget.ts
@@ -1,12 +1,8 @@
+import { Array } from 'effect'
 import type { ClaudeUsage, UsageWindow } from './provider/anthropic'
 import type { CodexUsage } from './provider/openai'
 import { glmRateLimits, type GlmUsage } from './provider/zai'
-import {
-  codexResetsAt,
-  formatCompactDuration,
-  glmResetsAt,
-  parseResetsAt,
-} from './reset'
+import { codexResetsAt, formatCompactDuration, parseResetsAt } from './reset'
 
 export interface WidgetLimit {
   readonly label: string
@@ -106,11 +102,9 @@ export function codexWidgetLimits(usage: CodexUsage, now: Date): WidgetLimit[] {
 }
 
 export function glmWidgetLimits(usage: GlmUsage): WidgetLimit[] {
-  const labels = ['5h', 'wk']
-  return glmRateLimits(usage).flatMap((limit, index) => {
-    const label = labels[index]
-    return label !== undefined && typeof limit.percentage === 'number'
-      ? [{ label, percent: limit.percentage, resetsAt: glmResetsAt(limit) }]
-      : []
-  })
+  return Array.zip(['5h', 'wk'], glmRateLimits(usage)).flatMap(([label, limit]) =>
+    typeof limit.percentage === 'number'
+      ? [{ label, percent: limit.percentage, resetsAt: limit.nextResetTime }]
+      : [],
+  )
 }

--- a/plugins/usage/src/widget.ts
+++ b/plugins/usage/src/widget.ts
@@ -1,6 +1,12 @@
 import type { ClaudeUsage, UsageWindow } from './provider/anthropic'
 import type { CodexUsage } from './provider/openai'
-import { codexResetsAt, formatCompactDuration, parseResetsAt } from './reset'
+import { zaiRateLimits, type ZaiUsageData } from './provider/zai'
+import {
+  codexResetsAt,
+  formatCompactDuration,
+  parseEpochMs,
+  parseResetsAt,
+} from './reset'
 
 export interface WidgetLimit {
   readonly label: string
@@ -93,6 +99,27 @@ export function codexWidgetLimits(usage: CodexUsage, now: Date): WidgetLimit[] {
             label: codexWindowLabel(window.limit_window_seconds),
             percent: window.used_percent,
             resetsAt: codexResetsAt(window, now),
+          },
+        ]
+      : [],
+  )
+}
+
+// ─── GLM Coding Plan ──────────────────────────────────────────────────────────
+
+/** Short label by position after the reset-time sort: first = 5h, second = week. */
+function glmLimitLabel(index: number): string {
+  return index === 0 ? '5h' : index === 1 ? 'wk' : `${index + 1}`
+}
+
+export function glmWidgetLimits(usage: ZaiUsageData): WidgetLimit[] {
+  return zaiRateLimits(usage).flatMap((limit, index) =>
+    typeof limit.percentage === 'number'
+      ? [
+          {
+            label: glmLimitLabel(index),
+            percent: limit.percentage,
+            resetsAt: parseEpochMs(limit.nextResetTime),
           },
         ]
       : [],

--- a/plugins/webfetch/README.md
+++ b/plugins/webfetch/README.md
@@ -37,7 +37,7 @@ Requests are sent with browser-like headers and transient failures are retried.
 ### Output
 
 Returns the page content as text. With `format: 'markdown'`, HTML pages are converted
-to Markdown; non-HTML responses are returned unchanged. With `format: 'html'`, the
+to Markdown and non-HTML responses are returned unchanged. With `format: 'html'`, the
 raw response body is returned.
 
 Long content is truncated from the head to fit the tool's output budget. When this

--- a/scripts/add-subtree.sh
+++ b/scripts/add-subtree.sh
@@ -40,7 +40,7 @@ if [[ -e "$prefix" ]]; then
 fi
 
 if ! git diff-index --quiet HEAD --; then
-  echo "error: working tree has uncommitted changes; commit or stash first" >&2
+  echo "error: working tree has uncommitted changes — commit or stash first" >&2
   exit 1
 fi
 

--- a/scripts/update-subtree.sh
+++ b/scripts/update-subtree.sh
@@ -17,7 +17,7 @@ if [[ ! -f "$registry" ]]; then
 fi
 
 if ! git diff-index --quiet HEAD --; then
-  echo "error: working tree has uncommitted changes; commit or stash first" >&2
+  echo "error: working tree has uncommitted changes — commit or stash first" >&2
   exit 1
 fi
 
@@ -31,7 +31,7 @@ if [[ "${1:-}" == "--all" ]]; then
   selection="$entries"
 else
   if ! command -v fzf >/dev/null 2>&1; then
-    echo "error: fzf is required for interactive mode; use --all to pull everything" >&2
+    echo "error: fzf is required for interactive mode — use --all to pull everything" >&2
     exit 1
   fi
   selection="$(printf '%s\n' "$entries" | fzf \

--- a/tooling/shared/src/statusline.ts
+++ b/tooling/shared/src/statusline.ts
@@ -9,7 +9,7 @@ export interface StatuslineSegment {
 
 const WIDGET_KEY = 'pi-plugins:statusline'
 
-// Each plugin bundles its own copy of this module; `Symbol.for` on
+// Each plugin bundles its own copy of this module, so `Symbol.for` on
 // `globalThis` gives them all the same registry inside one pi process.
 const REGISTRY_KEY = Symbol.for('@pi-plugins/statusline-registry')
 


### PR DESCRIPTION
## Summary

Adds Z.ai / Zhipu **GLM Coding Plan** as a third usage provider alongside Claude and OpenAI Codex.

- `/usage` gains a GLM section with the **5h** and **weekly** quota windows — percent bar, reset countdown, and credits used of total — plus the monthly **MCP tools** quota when the plan reports one
- The status-line widget shows `5h`/`wk` bars while a `zai` or `zai-coding-cn` model is active, on the same repaint/poll schedule as the other providers
- Credentials are read from the API key stored for the `zai` provider (`zai-coding-cn` for the `open.bigmodel.cn` China platform) — no OAuth machinery needed, so the GLM path is the simplest provider in the service
- `/usage` reports whichever platform has a stored key (global preferred); the widget follows the active model's provider

Example:

```text
GLM Coding (max)
  Session (5h)           [█░░░░░░░░░]   8% · resets in 4h 12m · 2,350 of 28,000 credits
  Week                   [░░░░░░░░░░]   1% · resets in 5d 1h · 2,350 of 140,000 credits
```

## Endpoint notes

`GET https://api.z.ai/api/monitor/usage/quota/limit` (mirrored at `https://open.bigmodel.cn/...`) is the undocumented console API the official usage dashboard calls; it's what community trackers (VS Code extensions, opencode plugins) use as well.

Two quirks the implementation accounts for:

- The platform answers **HTTP 200 for API errors** (`{"code":500,...}`), so success is validated inside the `{code,msg,data,success}` envelope rather than by status
- Plan generations differ: `TOKENS_LIMIT` (token plans), `CREDIT_LIMIT` (points plans), `TIME_LIMIT` (MCP monthly). Windows are disambiguated by sorting on `nextResetTime` (**epoch ms**, unlike Claude's ISO/epoch-seconds), matching the official dashboard's convention, since the `unit`/`number` fields are undocumented

## Testing

- [x] `turbo run check` (format, lint, types) and `tsdown` build pass
- [x] End-to-end against the live API: `/usage` renders the GLM section with real data (global + China endpoints)
- [x] Widget renders for both `zai` and `zai-coding-cn` models and clears when switching to an unrelated provider
- [x] Loaded in interactive pi via `pi -e ./plugins/usage` with no startup errors
