### PR TITLE
fix(claude-oauth): preserve Pi's model output limits

### DIFF
--- a/.changeset/claude-oauth-128k.md
+++ b/.changeset/claude-oauth-128k.md
@@ -1,0 +1,5 @@
+---
+'@pi-plugins/claude-oauth': patch
+---
+
+Raise OAuth requests' output ceiling to Claude Code's supported 128,000-token upper bound, so models such as Fable 5.1 are not restricted to Claude Code's 64,000-token default.

--- a/.changeset/claude-oauth-128k.md
+++ b/.changeset/claude-oauth-128k.md
@@ -1,5 +1,0 @@
----
-'@pi-plugins/claude-oauth': patch
----
-
-Raise OAuth requests' output ceiling to Claude Code's supported 128,000-token upper bound, so models such as Fable 5.1 are not restricted to Claude Code's 64,000-token default.

--- a/.changeset/claude-oauth-output-limits.md
+++ b/.changeset/claude-oauth-output-limits.md
@@ -1,0 +1,5 @@
+---
+'@pi-plugins/claude-oauth': patch
+---
+
+Preserve Pi's model-specific output limits on OAuth requests instead of replacing them with a fixed Claude Code ceiling.

--- a/plugins/claude-oauth/scripts/claude-trace.ts
+++ b/plugins/claude-oauth/scripts/claude-trace.ts
@@ -746,10 +746,6 @@ function extract(request: CapturedRequest): Extracted {
   } catch {
     // leave body empty; extraction just skips body-derived values
   }
-  if (typeof body.max_tokens === 'number') {
-    values['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] = String(body.max_tokens)
-  }
-
   const systemBlocks = body.system ?? []
   const billingText = systemBlocks.find((b) =>
     b.text?.startsWith(BILLING_PREFIX),
@@ -1112,10 +1108,7 @@ function writeBack(extracted: Extracted, request: CapturedRequest): void {
   }
 
   for (const [name, value] of Object.entries(extracted.values)) {
-    if (
-      name === 'CLAUDE_CODE_MAX_OUTPUT_TOKENS' ||
-      name === 'CLAUDE_CODE_STAINLESS_TIMEOUT'
-    ) {
+    if (name === 'CLAUDE_CODE_STAINLESS_TIMEOUT') {
       replaceNumber(name, value)
     } else {
       replaceString(name, value)

--- a/plugins/claude-oauth/src/constants.ts
+++ b/plugins/claude-oauth/src/constants.ts
@@ -4,9 +4,9 @@ export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.112.1'
 export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v26.3.0'
 export const CLAUDE_CODE_STAINLESS_TIMEOUT = 600
 
-// Claude Code caps requested output at 64k even when the model ceiling is higher
-// (e.g. Opus 128k); OAuth requests clamp to match the client.
-export const CLAUDE_CODE_MAX_OUTPUT_TOKENS = 64000
+// Claude Code defaults to 64k but supports a 128k upper bound through
+// CLAUDE_CODE_MAX_OUTPUT_TOKENS. Use that upper bound for OAuth requests.
+export const CLAUDE_CODE_MAX_OUTPUT_TOKENS = 128000
 
 // Claude Code fingerprints the billing header with
 // `SHA256(salt + msg[4] + msg[7] + msg[20] + version)[:3]`. The salt and indices

--- a/plugins/claude-oauth/src/constants.ts
+++ b/plugins/claude-oauth/src/constants.ts
@@ -4,10 +4,6 @@ export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.112.1'
 export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v26.3.0'
 export const CLAUDE_CODE_STAINLESS_TIMEOUT = 600
 
-// Claude Code defaults to 64k but supports a 128k upper bound through
-// CLAUDE_CODE_MAX_OUTPUT_TOKENS. Use that upper bound for OAuth requests.
-export const CLAUDE_CODE_MAX_OUTPUT_TOKENS = 128000
-
 // Claude Code fingerprints the billing header with
 // `SHA256(salt + msg[4] + msg[7] + msg[20] + version)[:3]`. The salt and indices
 // are pinned to the client and verified by `scripts/claude-trace.ts`.

--- a/plugins/claude-oauth/src/request.ts
+++ b/plugins/claude-oauth/src/request.ts
@@ -15,7 +15,6 @@ import {
   CLAUDE_CODE_BILLING_FINGERPRINT_INDICES,
   CLAUDE_CODE_BILLING_FINGERPRINT_SALT,
   CLAUDE_CODE_BILLING_HEADER_PREFIX,
-  CLAUDE_CODE_MAX_OUTPUT_TOKENS,
   CLAUDE_CODE_STAINLESS_PACKAGE_VERSION,
   CLAUDE_CODE_STAINLESS_RUNTIME_VERSION,
   CLAUDE_CODE_STAINLESS_TIMEOUT,
@@ -101,7 +100,6 @@ interface AnthropicPayload {
   messages?: Array<{ role?: string; content?: unknown }>
   system?: SystemBlock[]
   tools?: unknown[]
-  max_tokens?: number
   metadata?: { user_id?: unknown }
   thinking?: { type?: unknown }
   context_management?: unknown
@@ -212,13 +210,6 @@ export function rewriteForClaudeCode(
       account_uuid: accountUuid,
       session_id: sessionId,
     }),
-  }
-
-  if (
-    Predicate.isNumber(typed.max_tokens) &&
-    typed.max_tokens > CLAUDE_CODE_MAX_OUTPUT_TOKENS
-  ) {
-    typed.max_tokens = CLAUDE_CODE_MAX_OUTPUT_TOKENS
   }
 
   if (typed.thinking?.type === 'adaptive' || typed.thinking?.type === 'enabled') {


### PR DESCRIPTION
> *This was generated by AI during triage.*

Pi already chooses a model-specific `max_tokens` value and reduces it when the current context cannot accommodate the model's full output capacity. The adapter should preserve that decision rather than replacing it with a fixed Claude Code ceiling.

This removes the adapter's global output-token clamp, so models such as Fable 5 retain Pi's configured 128,000-token limit while models with smaller limits remain unchanged. It also stops the trace utility from treating a model-dependent observed `max_tokens` value as a global pinned constant.

Includes a patch changeset.
