### PR TITLE
fix(claude-oauth): preserve pi request betas

### DIFF
--- a/.changeset/claude-oauth-preserve-pi-betas.md
+++ b/.changeset/claude-oauth-preserve-pi-betas.md
@@ -1,0 +1,5 @@
+---
+'@pi-plugins/claude-oauth': patch
+---
+
+Preserve Pi's request-specific Anthropic beta features when applying Claude Code OAuth headers, including the per-turn effort and thinking-binding betas added in Pi 0.85.0.

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
           pnpm install --frozen-lockfile
-          turbo run format:check lint check-types build
+          turbo run format:check lint check-types build test
         '';
       };
     in {

--- a/plugins/claude-oauth/package.json
+++ b/plugins/claude-oauth/package.json
@@ -39,9 +39,10 @@
     "prepack": "pnpm run build",
     "build": "tsdown",
     "capture": "node scripts/claude-trace.ts",
-    "check": "pnpm run lint && pnpm run check-types && pnpm run format:check",
+    "check": "pnpm run lint && pnpm run check-types && pnpm run format:check && pnpm run test",
     "check-types": "tsc -b",
     "lint": "oxlint",
+    "test": "node --experimental-strip-types --import ./test/resolve-typescript.mjs --test ./test/*.test.mjs",
     "format": "oxfmt",
     "format:check": "oxfmt --check"
   },

--- a/plugins/claude-oauth/src/cch.ts
+++ b/plugins/claude-oauth/src/cch.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto'
+import { Array, pipe, String } from 'effect'
 import {
   CCH_PLACEHOLDER,
   CCH_SEED,
   CLAUDE_CODE_BILLING_HEADER_PREFIX,
-  CLAUDE_CODE_SERVER_FALLBACK_BETA,
 } from './constants'
 import { xxHash64 } from './utils'
 
@@ -167,20 +167,23 @@ export function wrapFetchForCch(
     const inputHeaders =
       init?.headers ?? (input instanceof Request ? input.headers : undefined)
     const headers = new Headers(inputHeaders)
-    const preserveServerFallbackBeta = (headers.get('anthropic-beta') ?? '')
-      .split(',')
-      .some((beta) => beta.trim() === CLAUDE_CODE_SERVER_FALLBACK_BETA)
+    // Pi selects betas for the request fields it emitted. Preserve them when
+    // applying Claude Code's baseline so body and header capabilities stay aligned.
+    const incomingBetaHeader = headers.get('anthropic-beta') ?? ''
     for (const [name, value] of Object.entries(claudeHeaders)) {
       headers.set(name, value)
     }
-    if (preserveServerFallbackBeta) {
-      const betas = headers.get('anthropic-beta')
-      headers.set(
-        'anthropic-beta',
-        betas
-          ? `${betas},${CLAUDE_CODE_SERVER_FALLBACK_BETA}`
-          : CLAUDE_CODE_SERVER_FALLBACK_BETA,
-      )
+    const mergedBetas = pipe(
+      [headers.get('anthropic-beta') ?? '', incomingBetaHeader],
+      Array.flatMap(String.split(',')),
+      Array.map(String.trim),
+      Array.filter(String.isNonEmpty),
+      Array.dedupe,
+    )
+    if (mergedBetas.length > 0) {
+      headers.set('anthropic-beta', mergedBetas.join(','))
+    } else {
+      headers.delete('anthropic-beta')
     }
     headers.delete('anthropic-client-platform')
     headers.delete('anthropic-client-version')

--- a/plugins/claude-oauth/test/cch.test.mjs
+++ b/plugins/claude-oauth/test/cch.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { wrapFetchForCch } from '../src/cch.ts'
+
+const betaFeatures = (headers) =>
+  (headers.get('anthropic-beta') ?? '')
+    .split(',')
+    .map((feature) => feature.trim())
+    .filter(Boolean)
+
+test('preserves pi request betas when applying Claude Code headers', async () => {
+  const claudeBetas = [
+    'claude-code-20250219',
+    'oauth-2025-04-20',
+    'context-management-2025-06-27',
+  ]
+  const piBetas = [
+    'oauth-2025-04-20',
+    'server-side-fallback-2026-07-01',
+    'mid-conversation-output-config-2026-07-01',
+    'thinking-binding-controls-2026-08-01',
+  ]
+  let sentHeaders
+  const baseFetch = async (_input, init) => {
+    sentHeaders = new Headers(init?.headers)
+    return new Response(null, { status: 204 })
+  }
+  const wrapped = wrapFetchForCch(baseFetch, {
+    'anthropic-beta': claudeBetas.join(','),
+  })
+  const body = JSON.stringify({
+    model: 'claude-fable-5-1',
+    messages: [
+      { role: 'user', content: 'Hello' },
+      {
+        role: 'system',
+        content: [],
+        output_config: { effort: 'high' },
+      },
+    ],
+    system: [
+      {
+        type: 'text',
+        text: 'x-anthropic-billing-header: cch=00000;',
+      },
+    ],
+  })
+
+  await wrapped('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'anthropic-beta': piBetas.join(',') },
+    body,
+  })
+
+  assert.ok(sentHeaders)
+  const sentBetas = betaFeatures(sentHeaders)
+  const expectedBetas = [...new Set([...claudeBetas, ...piBetas])]
+  assert.deepEqual(new Set(sentBetas), new Set(expectedBetas))
+  assert.equal(sentBetas.length, expectedBetas.length)
+})

--- a/plugins/claude-oauth/test/resolve-typescript.mjs
+++ b/plugins/claude-oauth/test/resolve-typescript.mjs
@@ -1,0 +1,11 @@
+import { registerHooks } from 'node:module'
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const isRelative = specifier.startsWith('./') || specifier.startsWith('../')
+    const hasExtension = /\.[^/]+$/u.test(specifier)
+    return isRelative && !hasExtension
+      ? nextResolve(`${specifier}.ts`, context)
+      : nextResolve(specifier, context)
+  },
+})

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,9 @@
       "cache": false
     },
     "format:check": {},
+    "test": {
+      "dependsOn": ["^test"]
+    },
     "//#format": {
       "cache": false
     },


### PR DESCRIPTION
## Summary

- merge Pi's incoming `anthropic-beta` features with the Claude Code baseline instead of preserving only the server-fallback beta
- deduplicate beta features while keeping the Claude Code baseline first
- add a transport-level regression test and run package tests from the repository `ci` command
- add a patch changeset for `@pi-plugins/claude-oauth`

## Root cause

Pi 0.85.0 adds per-turn effort system messages and thinking binding controls for supported Claude models. Their payload fields require these request-specific betas:

- `mid-conversation-output-config-2026-07-01`
- `thinking-binding-controls-2026-08-01`

The OAuth transport wrapper replaced Pi's generated beta header with the captured Claude Code baseline and only restored `server-side-fallback-2026-07-01`. Anthropic consequently rejected `messages.1.output_config` as an extra input.

Preserving every incoming beta keeps Pi's generated payload and capability header aligned and avoids repeating this incompatibility for future request-specific features.

## Testing

- regression test observed red before the implementation and green after it
- `pnpm exec turbo run format:check lint check-types build test`
- Pi 0.85.0 mocked provider request using the built plugin: `claude-fable-5-1` completed with both required betas present
