### PR TITLE
refactor: apply the AGENTS.md code style across all packages

### DIFF
--- a/plugins/checkpoint/src/file-lock.ts
+++ b/plugins/checkpoint/src/file-lock.ts
@@ -27,26 +27,26 @@ export interface FileLock {
 export const make = Effect.fnUntraced(function* (lockPath: string) {
   const fs = yield* FileSystem.FileSystem
 
+  // A holder that stopped heartbeating (e.g. was killed) is broken.
+  const breakIfStale = Effect.fnUntraced(function* () {
+    const { mtime } = yield* fs.stat(lockPath)
+    const now = yield* DateTime.now
+    const stale = Option.exists(mtime, (time) =>
+      Duration.isGreaterThan(
+        DateTime.distance(DateTime.fromDateUnsafe(time), now),
+        Duration.seconds(30),
+      ),
+    )
+    if (stale) {
+      yield* fs.remove(lockPath, { recursive: true })
+    }
+  }, Effect.ignore)
+
   const acquire = Effect.acquireRelease(fs.makeDirectory(lockPath), () =>
     Effect.ignore(fs.remove(lockPath, { recursive: true })),
   ).pipe(
     Effect.tapError((error) =>
-      error.reason._tag !== 'AlreadyExists'
-        ? Effect.void
-        : Effect.gen(function* () {
-            // A holder that stopped heartbeating (e.g. was killed) is broken.
-            const { mtime } = yield* fs.stat(lockPath)
-            const now = yield* DateTime.now
-            const stale = Option.exists(mtime, (time) =>
-              Duration.isGreaterThan(
-                DateTime.distance(DateTime.fromDateUnsafe(time), now),
-                Duration.seconds(30),
-              ),
-            )
-            if (stale) {
-              yield* fs.remove(lockPath, { recursive: true })
-            }
-          }).pipe(Effect.ignore),
+      error.reason._tag === 'AlreadyExists' ? breakIfStale() : Effect.void,
     ),
     Effect.retry({
       while: (error) => error.reason._tag === 'AlreadyExists',

--- a/plugins/checkpoint/src/file-lock.ts
+++ b/plugins/checkpoint/src/file-lock.ts
@@ -9,7 +9,6 @@ import {
   Scope,
 } from 'effect'
 
-/** Failed to acquire the lock in time, or the attempt itself errored. */
 export class FileLockError extends Data.TaggedError('FileLockError')<{
   lockPath: string
   cause: unknown
@@ -19,46 +18,35 @@ export class FileLockError extends Data.TaggedError('FileLockError')<{
   }
 }
 
-/** An inter-process lock backed by a lock directory on disk. */
 export interface FileLock {
-  /** Runs `self` while holding the lock. */
   withLock<A, E, R>(
     self: Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E | FileLockError, R>
 }
 
-/**
- * Creates an inter-process `FileLock` at `lockPath`.
- *
- * Waiters fail with a `FileLockError` after 10 seconds. Abandoned locks are
- * broken: holders refresh the lock's mtime every 10 seconds, and a lock not
- * refreshed for 30 seconds is considered dead.
- */
 export const make = Effect.fnUntraced(function* (lockPath: string) {
   const fs = yield* FileSystem.FileSystem
 
-  /** Removes the lock if its holder stopped heartbeating (e.g. was killed). */
-  const breakIfStale = Effect.fnUntraced(function* () {
-    const { mtime } = yield* fs.stat(lockPath)
-    const now = yield* DateTime.now
-    const stale = Option.exists(mtime, (time) =>
-      Duration.isGreaterThan(
-        DateTime.distance(DateTime.fromDateUnsafe(time), now),
-        Duration.seconds(30),
-      ),
-    )
-    if (stale) {
-      yield* fs.remove(lockPath, { recursive: true })
-    }
-  }, Effect.ignore)
-
-  // Uninterruptible `makeDirectory` acquire; the polling between attempts
-  // stays interruptible.
   const acquire = Effect.acquireRelease(fs.makeDirectory(lockPath), () =>
     Effect.ignore(fs.remove(lockPath, { recursive: true })),
   ).pipe(
     Effect.tapError((error) =>
-      error.reason._tag === 'AlreadyExists' ? breakIfStale() : Effect.void,
+      error.reason._tag !== 'AlreadyExists'
+        ? Effect.void
+        : Effect.gen(function* () {
+            // A holder that stopped heartbeating (e.g. was killed) is broken.
+            const { mtime } = yield* fs.stat(lockPath)
+            const now = yield* DateTime.now
+            const stale = Option.exists(mtime, (time) =>
+              Duration.isGreaterThan(
+                DateTime.distance(DateTime.fromDateUnsafe(time), now),
+                Duration.seconds(30),
+              ),
+            )
+            if (stale) {
+              yield* fs.remove(lockPath, { recursive: true })
+            }
+          }).pipe(Effect.ignore),
     ),
     Effect.retry({
       while: (error) => error.reason._tag === 'AlreadyExists',
@@ -69,7 +57,6 @@ export const make = Effect.fnUntraced(function* (lockPath: string) {
     Effect.mapError((cause) => new FileLockError({ lockPath, cause })),
   )
 
-  /** Marks the lock as live so waiters do not break it. */
   const heartbeat = Effect.gen(function* () {
     const now = yield* DateTime.nowAsDate
     yield* fs.utimes(lockPath, now, now)

--- a/plugins/checkpoint/src/index.ts
+++ b/plugins/checkpoint/src/index.ts
@@ -8,15 +8,12 @@ import { runHandler } from '@pi-plugins/shared/run'
 import { Array, Effect, Option, pipe, Schema } from 'effect'
 import { Snapshotter, SnapshotterError } from './snapshot'
 
-/** `customType` of the hidden session entries that carry a snapshot tree hash. */
 const CHECKPOINT_TYPE = 'file-checkpoint'
 
-/** User-facing choices when navigating to a point with a different file state. */
 const CHOICE_CONVERSATION = 'Conversation only (keep files as they are)'
 const CHOICE_RESTORE = 'Conversation and files'
 const CHOICE_CANCEL = 'Cancel navigation'
 
-/** The tree hash stored on `entry`, if it is one of our checkpoint entries. */
 function checkpointOf(entry: SessionEntry | undefined): string | undefined {
   if (entry?.type !== 'custom' || entry.customType !== CHECKPOINT_TYPE) {
     return undefined
@@ -29,7 +26,6 @@ function checkpointOf(entry: SessionEntry | undefined): string | undefined {
   )
 }
 
-/** Nearest checkpoint at or above `fromId` in the session tree. */
 function nearestCheckpoint(
   session: ExtensionContext['sessionManager'],
   fromId: string | null,
@@ -51,34 +47,13 @@ function nearestCheckpoint(
   return undefined
 }
 
-/**
- * The file state associated with navigating to `targetId`: a checkpoint
- * directly below the target, or the nearest ancestor checkpoint.
- */
-function restoreTree(
-  session: ExtensionContext['sessionManager'],
-  targetId: string,
-): string | undefined {
-  return pipe(
-    session.getEntries(),
-    Array.findFirst((entry) =>
-      entry.parentId === targetId
-        ? Option.fromUndefinedOr(checkpointOf(entry))
-        : Option.none(),
-    ),
-    Option.getOrElse(() => nearestCheckpoint(session, targetId)),
-  )
-}
-
 export default function checkpoint(pi: ExtensionAPI) {
   let snapshotter: Snapshotter['Service'] | undefined
 
   pi.on('session_start', async (_event, ctx) => {
-    // Only active inside git worktrees.
     snapshotter = await runHandler(
       Snapshotter.make(ctx.cwd).pipe(
         Effect.provide(NodeServices.layer),
-        // Being outside a worktree is the normal way to have no snapshotter.
         Effect.catchIf(
           (error) =>
             error instanceof SnapshotterError && error.kind === 'NotAWorktree',
@@ -96,17 +71,10 @@ export default function checkpoint(pi: ExtensionAPI) {
     )
   })
 
-  /**
-   * Records the current file state as a checkpoint at the current leaf,
-   * skipping entries when the branch already ends in an identical state.
-   * Running on both `turn_start` and `turn_end` brackets every turn with a
-   * before/after snapshot pair.
-   */
   const recordCheckpoint = async (ctx: ExtensionContext) => {
     if (!snapshotter) {
       return
     }
-    // Current worktree state as a tree hash, or undefined when tracking fails.
     const tree = await runHandler(snapshotter.track())
     if (!tree) {
       return
@@ -117,6 +85,7 @@ export default function checkpoint(pi: ExtensionAPI) {
     }
   }
 
+  // Both hooks bracket every turn with a before/after snapshot pair.
   pi.on('turn_start', async (_event, ctx) => recordCheckpoint(ctx))
   pi.on('turn_end', async (_event, ctx) => recordCheckpoint(ctx))
 
@@ -163,7 +132,16 @@ export default function checkpoint(pi: ExtensionAPI) {
       return undefined
     }
     const session = ctx.sessionManager
-    const target = restoreTree(session, event.preparation.targetId)
+    const targetId = event.preparation.targetId
+    const target = pipe(
+      session.getEntries(),
+      Array.findFirst((entry) =>
+        entry.parentId === targetId
+          ? Option.fromUndefinedOr(checkpointOf(entry))
+          : Option.none(),
+      ),
+      Option.getOrElse(() => nearestCheckpoint(session, targetId)),
+    )
     if (!target) {
       return undefined
     }
@@ -181,8 +159,8 @@ export default function checkpoint(pi: ExtensionAPI) {
       return choice === CHOICE_CANCEL ? { cancel: true } : undefined
     }
 
-    // Preserve the abandoned state on the old branch so that navigating back
-    // to it can restore the files again (redo).
+    // Checkpoint the abandoned state on the old branch so navigating back can
+    // restore it again (redo).
     if (nearestCheckpoint(session, session.getLeafId()) !== current) {
       pi.appendEntry(CHECKPOINT_TYPE, { tree: current })
     }

--- a/plugins/checkpoint/src/snapshot.ts
+++ b/plugins/checkpoint/src/snapshot.ts
@@ -26,12 +26,6 @@ export class SnapshotterError extends Schema.TaggedErrorClass<SnapshotterError>(
   },
 ) {}
 
-/**
- * Snapshots the git worktree containing `cwd` into a shadow repository (a
- * separate `GIT_DIR` outside the project).
- *
- * `make` fails with a `NotAWorktree` error outside git worktrees.
- */
 export class Snapshotter extends Context.Service<Snapshotter>()(
   '@pi-plugins/checkpoint/Snapshotter',
   {
@@ -41,11 +35,6 @@ export class Snapshotter extends Context.Service<Snapshotter>()(
       const crypto = yield* Crypto.Crypto
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
 
-      /**
-       * Runs `git args` in `dir` and returns its stdout, failing with a
-       * `GitError` on non-zero exit. Invocations are killed after a timeout
-       * so a hung git process cannot stall the agent's hooks indefinitely.
-       */
       const git = Effect.fnUntraced(
         function* (args: readonly string[], dir: string) {
           const handle = yield* spawner.spawn(
@@ -86,10 +75,6 @@ export class Snapshotter extends Context.Service<Snapshotter>()(
           ),
       )
 
-      /**
-       * Wraps `args` with the arguments that point git at the shadow
-       * repository and additional safety configuration.
-       */
       const shadowGit = (args: readonly string[]): readonly string[] => [
         '-c',
         'core.autocrlf=false',
@@ -104,7 +89,6 @@ export class Snapshotter extends Context.Service<Snapshotter>()(
         ...args,
       ]
 
-      // Resolve the canonical repository root by which the shadow `GIT_DIR` is keyed.
       const worktree = yield* git(['rev-parse', '--show-toplevel'], cwd).pipe(
         Effect.map(String.trim),
         Effect.catchTag('SnapshotterError', (error) =>
@@ -144,17 +128,11 @@ export class Snapshotter extends Context.Service<Snapshotter>()(
         }),
       )
 
-      /**
-       * Lists the paths currently tracked by the shadow index.
-       */
       const listIndexFiles = Effect.fnUntraced(function* () {
         const out = yield* git(shadowGit(['ls-files', '-z']), worktree)
         return pipe(out, String.split('\0'), Array.filter(String.isNonEmpty))
       })
 
-      /**
-       * Creates a snapshot of the current worktree state.
-       */
       const track = Effect.fn('Snapshotter.track')(function* () {
         yield* git(shadowGit(['add', '--all']), worktree)
         return yield* git(shadowGit(['write-tree']), worktree).pipe(
@@ -162,11 +140,7 @@ export class Snapshotter extends Context.Service<Snapshotter>()(
         )
       }, lock.withLock)
 
-      /**
-       * Applies a snapshot to the worktree: checks out its files and deletes
-       * files tracked in the shadow index but absent from the snapshot.
-       * Assumes the shadow index reflects the current worktree state.
-       */
+      // Assumes the shadow index reflects the current worktree state.
       const applyTree = Effect.fnUntraced(function* (tree: string) {
         const before = yield* listIndexFiles()
         yield* git(shadowGit(['read-tree', tree]), worktree)
@@ -180,15 +154,7 @@ export class Snapshotter extends Context.Service<Snapshotter>()(
         )
       })
 
-      /**
-       * Restores the worktree to the state of a snapshot, deleting files that
-       * were present in the worktree but not in the snapshot.
-       *
-       * A failed restore is rolled back to the pre-restore state so that a
-       * partial checkout never leaves the worktree in a mixed state.
-       */
       const restore = Effect.fn('Snapshotter.restore')(function* (tree: string) {
-        // Snapshot the current state as the rollback point.
         yield* git(shadowGit(['add', '--all']), worktree)
         const current = yield* git(shadowGit(['write-tree']), worktree).pipe(
           Effect.map(String.trim),
@@ -210,10 +176,6 @@ export class Snapshotter extends Context.Service<Snapshotter>()(
         )
       }, lock.withLock)
 
-      /**
-       * Prunes all stored checkpoint objects and records the current worktree
-       * as a fresh baseline so checkpointing can continue immediately.
-       */
       const cleanup = Effect.fn('Snapshotter.cleanup')(function* () {
         const index = path.join(gitdir, 'index')
         if (yield* fs.exists(index)) {

--- a/plugins/claude-oauth/src/cch.ts
+++ b/plugins/claude-oauth/src/cch.ts
@@ -92,7 +92,7 @@ function findNextIgnoredRange(body: Buffer, offset: number): ByteRange | undefin
   return earliest
 }
 
-// Claude excludes mutable routing fields and model values from the attestation.
+// Mutable routing fields and model values are excluded from the attestation.
 function canonicalizeForCch(body: Buffer): Buffer {
   const chunks: Buffer[] = []
   let length = 0
@@ -167,8 +167,7 @@ export function wrapFetchForCch(
     const inputHeaders =
       init?.headers ?? (input instanceof Request ? input.headers : undefined)
     const headers = new Headers(inputHeaders)
-    // Pi selects betas for the request fields it emitted. Preserve them when
-    // applying Claude Code's baseline so body and header capabilities stay aligned.
+    // Pi's betas match the request fields it emitted; keep them alongside the baseline.
     const incomingBetaHeader = headers.get('anthropic-beta') ?? ''
     for (const [name, value] of Object.entries(claudeHeaders)) {
       headers.set(name, value)

--- a/plugins/claude-oauth/src/constants.ts
+++ b/plugins/claude-oauth/src/constants.ts
@@ -4,23 +4,19 @@ export const CLAUDE_CODE_STAINLESS_PACKAGE_VERSION = '0.112.1'
 export const CLAUDE_CODE_STAINLESS_RUNTIME_VERSION = 'v26.3.0'
 export const CLAUDE_CODE_STAINLESS_TIMEOUT = 600
 
-// Claude Code fingerprints the billing header with
-// `SHA256(salt + msg[4] + msg[7] + msg[20] + version)[:3]`. The salt and indices
-// are pinned to the client and verified by `scripts/claude-trace.ts`.
+// Billing header fingerprint: `SHA256(salt + msg[4] + msg[7] + msg[20] + version)[:3]`.
+// Pinned to the client and verified by `scripts/claude-trace.ts`.
 export const CLAUDE_CODE_BILLING_FINGERPRINT_SALT = '59cf53e54c78'
 export const CLAUDE_CODE_BILLING_FINGERPRINT_INDICES = [4, 7, 20] as const
 
-// The billing header text prepended by the plugin. Its `cch` field starts as the
-// placeholder and the fetch wrapper patches in the real request-integrity value.
+// The fetch wrapper patches the real request-integrity value over the placeholder.
 export const CLAUDE_CODE_BILLING_HEADER_PREFIX = 'x-anthropic-billing-header:'
 export const CCH_PLACEHOLDER = 'cch=00000'
 
-// Seed for the XXH64 that produces the `cch` value; reverse-engineered from and
-// pinned to the client, verified by `scripts/claude-trace.ts`.
+// XXH64 seed for `cch`; pinned to the client and verified by `scripts/claude-trace.ts`.
 export const CCH_SEED = 0x4d659218e32a3268n
 
-// pi injects this exact block as system[0] on OAuth requests. Its presence is the
-// trigger to apply the rest of the Claude Code request details.
+// pi injects this exact block as system[0] on OAuth requests.
 export const PI_ANTHROPIC_OAUTH_SENTINEL =
   "You are Claude Code, Anthropic's official CLI for Claude."
 
@@ -43,6 +39,5 @@ export const CLAUDE_CODE_AGENT_BETAS = [
   'cache-diagnosis-2026-04-07',
 ] as const
 
-// Pi conditionally installs this beta alongside its model fallbacks. Preserve
-// that decision when replacing Pi's beta header with the captured baseline.
+// Installed by pi alongside its model fallbacks.
 export const CLAUDE_CODE_SERVER_FALLBACK_BETA = 'server-side-fallback-2026-07-01'

--- a/plugins/claude-oauth/src/index.ts
+++ b/plugins/claude-oauth/src/index.ts
@@ -4,32 +4,20 @@ import { buildProviderHeaders, rewriteForClaudeCode } from './request'
 
 let fetchWrapped = false
 
-/**
- * Install the Claude request transport wrapper on the global fetch. The
- * Anthropic SDK resolves `fetch` at client construction, so pi's fresh client
- * picks it up for every request.
- */
-function installCchFetchWrapper(): void {
-  if (fetchWrapped) {
-    return
-  }
-  const target = globalThis as { fetch?: typeof fetch }
-  if (typeof target.fetch !== 'function') {
-    return
-  }
-  target.fetch = wrapFetchForCch(
-    target.fetch.bind(globalThis) as typeof fetch,
-    buildProviderHeaders(),
-  )
-  fetchWrapped = true
-}
-
 export default function claudeOauth(pi: ExtensionAPI): void {
-  installCchFetchWrapper()
+  // The Anthropic SDK resolves `fetch` at client construction, so pi's fresh
+  // client picks the wrapper up for every request.
+  const target = globalThis as { fetch?: typeof fetch }
+  if (!fetchWrapped && typeof target.fetch === 'function') {
+    target.fetch = wrapFetchForCch(
+      target.fetch.bind(globalThis) as typeof fetch,
+      buildProviderHeaders(),
+    )
+    fetchWrapped = true
+  }
 
-  // Returning the payload replaces it; returning `undefined` leaves it unchanged.
-  // `short` is also set by @pi-plugins/subagent to prevent extended retention
-  // from leaking into the fresh child process through this globally loaded plugin.
+  // @pi-plugins/subagent sets `short` on its children so extended retention does
+  // not leak into them through this globally loaded plugin.
   pi.on('before_provider_request', (event) =>
     rewriteForClaudeCode(
       event.payload,

--- a/plugins/claude-oauth/src/request.ts
+++ b/plugins/claude-oauth/src/request.ts
@@ -24,25 +24,6 @@ import {
 import { sanitizeSystemText } from './system-prompt'
 import { firstUserMessageText, isTextBlock } from './utils'
 
-// The `os.arch()` / `os.platform()` values the SDK reports, mapped to the labels
-// Stainless emits. Anything unlisted falls through to an `other::<value>` marker.
-const mapStainlessArch = (value: string): string =>
-  Match.value(value.toLowerCase()).pipe(
-    Match.whenOr('amd64', 'x64', () => 'x64'),
-    Match.whenOr('arm64', 'aarch64', () => 'arm64'),
-    Match.whenOr('386', 'x86', 'ia32', () => 'x86'),
-    Match.orElse((key) => `other::${key}`),
-  )
-
-const mapStainlessOs = (value: string): string =>
-  Match.value(value.toLowerCase()).pipe(
-    Match.when('darwin', () => 'MacOS'),
-    Match.whenOr('win32', 'windows', () => 'Windows'),
-    Match.when('linux', () => 'Linux'),
-    Match.when('freebsd', () => 'FreeBSD'),
-    Match.orElse((key) => `Other::${key}`),
-  )
-
 export function buildProviderHeaders(): Record<string, string> {
   return {
     'user-agent': `claude-cli/${CLAUDE_CODE_VERSION} (external, local-agent, agent-sdk/${CLAUDE_AGENT_SDK_VERSION})`,
@@ -54,32 +35,24 @@ export function buildProviderHeaders(): Record<string, string> {
     'x-stainless-package-version': CLAUDE_CODE_STAINLESS_PACKAGE_VERSION,
     'x-stainless-runtime': 'node',
     'x-stainless-lang': 'js',
-    'x-stainless-arch': mapStainlessArch(osArch()),
-    'x-stainless-os': mapStainlessOs(osPlatform()),
+    'x-stainless-arch': Match.value(osArch().toLowerCase()).pipe(
+      Match.whenOr('amd64', 'x64', () => 'x64'),
+      Match.whenOr('arm64', 'aarch64', () => 'arm64'),
+      Match.whenOr('386', 'x86', 'ia32', () => 'x86'),
+      Match.orElse((key) => `other::${key}`),
+    ),
+    'x-stainless-os': Match.value(osPlatform().toLowerCase()).pipe(
+      Match.when('darwin', () => 'MacOS'),
+      Match.whenOr('win32', 'windows', () => 'Windows'),
+      Match.when('linux', () => 'Linux'),
+      Match.when('freebsd', () => 'FreeBSD'),
+      Match.orElse((key) => `Other::${key}`),
+    ),
     'x-stainless-timeout': String(CLAUDE_CODE_STAINLESS_TIMEOUT),
   }
 }
 
-/**
- * Builds the `x-anthropic-billing-header` text for system[0]. The `cch=00000`
- * placeholder is filled in later by the fetch wrapper once the body is serialized.
- */
-function createBillingHeader(firstUserMessage: string): string {
-  const fingerprintSeed = CLAUDE_CODE_BILLING_FINGERPRINT_INDICES.map(
-    (i) => firstUserMessage[i] ?? '0',
-  ).join('')
-  const versionSuffix = createHash('sha256')
-    .update(
-      `${CLAUDE_CODE_BILLING_FINGERPRINT_SALT}${fingerprintSeed}${CLAUDE_CODE_VERSION}`,
-    )
-    .digest('hex')
-    .slice(0, 3)
-  return `${CLAUDE_CODE_BILLING_HEADER_PREFIX} cc_version=${CLAUDE_CODE_VERSION}.${versionSuffix}; cc_entrypoint=local-agent; ${CCH_PLACEHOLDER}; cc_prompt_id=${randomUUID()};`
-}
-
-// Claude Code sends `metadata.user_id` as a JSON identity envelope: device_id
-// is machine-stable and session_id is per process. userInfo()
-// can throw in locked-down sandboxes, so fall back to a hostname-only seed.
+// `userInfo()` can throw in locked-down sandboxes.
 let machineSeed: string
 try {
   machineSeed = `${hostname()}:${userInfo().username}:${homedir()}`
@@ -106,7 +79,6 @@ interface AnthropicPayload {
   diagnostics?: unknown
 }
 
-/** Configure an existing cache breakpoint for extended or standard retention. */
 function configureCacheTtl(block: unknown, extended: boolean): void {
   if (!Predicate.isObject(block)) {
     return
@@ -126,34 +98,7 @@ function configureCacheTtl(block: unknown, extended: boolean): void {
   }
 }
 
-/** Update only the cache breakpoints pi already placed in the payload. */
-function configurePayloadCacheTtls(
-  payload: AnthropicPayload,
-  extended: boolean,
-): void {
-  for (const block of payload.system ?? []) {
-    configureCacheTtl(block, extended)
-  }
-  for (const tool of payload.tools ?? []) {
-    configureCacheTtl(tool, extended)
-  }
-  for (const message of payload.messages ?? []) {
-    if (Array.isArray(message.content)) {
-      for (const block of message.content) {
-        configureCacheTtl(block, extended)
-      }
-    }
-  }
-}
-
-/**
- * Rewrites an OAuth Anthropic payload to match the Claude Code client, returning
- * it. Returns `undefined` — leaving the request unchanged — for any payload that
- * is not a Claude Code OAuth request.
- *
- * The payload is mutated in place rather than decoded/re-encoded so that fields
- * this plugin does not model pass through byte-for-byte.
- */
+// Mutated in place so fields this plugin does not model pass through untouched.
 export function rewriteForClaudeCode(
   payload: unknown,
   extendedCacheTtl = true,
@@ -162,14 +107,11 @@ export function rewriteForClaudeCode(
     return undefined
   }
   const typed = payload as AnthropicPayload
-  // Pi only adds this sentinel to Anthropic OAuth payloads.
   const system = typed.system
   if (!Array.isArray(system) || system[0]?.text !== PI_ANTHROPIC_OAUTH_SENTINEL) {
     return undefined
   }
 
-  // Replace the OAuth sentinel with the Agent SDK identity and rewrite pi's
-  // self-references in the remaining system blocks. Emptied blocks drop out.
   const normalized = Array.flatMap(system, (block) => {
     if (!isTextBlock(block)) {
       return [block]
@@ -181,11 +123,19 @@ export function rewriteForClaudeCode(
     return text ? [{ ...block, text }] : []
   })
 
-  // Prepend the billing-header block; its `cch` placeholder is filled in by the
-  // fetch wrapper once the body is serialized.
+  const firstUserMessage = firstUserMessageText(typed.messages ?? [])
+  const fingerprintSeed = CLAUDE_CODE_BILLING_FINGERPRINT_INDICES.map(
+    (i) => firstUserMessage[i] ?? '0',
+  ).join('')
+  const versionSuffix = createHash('sha256')
+    .update(
+      `${CLAUDE_CODE_BILLING_FINGERPRINT_SALT}${fingerprintSeed}${CLAUDE_CODE_VERSION}`,
+    )
+    .digest('hex')
+    .slice(0, 3)
   normalized.unshift({
     type: 'text',
-    text: createBillingHeader(firstUserMessageText(typed.messages ?? [])),
+    text: `${CLAUDE_CODE_BILLING_HEADER_PREFIX} cc_version=${CLAUDE_CODE_VERSION}.${versionSuffix}; cc_entrypoint=local-agent; ${CCH_PLACEHOLDER}; cc_prompt_id=${randomUUID()};`,
   })
   typed.system = normalized
 
@@ -219,9 +169,19 @@ export function rewriteForClaudeCode(
   }
   typed.diagnostics = { previous_message_id: null }
 
-  // The OAuth beta supports one-hour prompt caching. Update the breakpoints pi
-  // already emitted without enabling extended retention for other auth modes.
-  configurePayloadCacheTtls(typed, extendedCacheTtl)
+  for (const block of typed.system) {
+    configureCacheTtl(block, extendedCacheTtl)
+  }
+  for (const tool of typed.tools ?? []) {
+    configureCacheTtl(tool, extendedCacheTtl)
+  }
+  for (const message of typed.messages ?? []) {
+    if (Array.isArray(message.content)) {
+      for (const block of message.content) {
+        configureCacheTtl(block, extendedCacheTtl)
+      }
+    }
+  }
 
   return typed
 }

--- a/plugins/claude-oauth/src/request.ts
+++ b/plugins/claude-oauth/src/request.ts
@@ -52,7 +52,9 @@ export function buildProviderHeaders(): Record<string, string> {
   }
 }
 
-// `userInfo()` can throw in locked-down sandboxes.
+// Claude Code sends `metadata.user_id` as a JSON identity envelope: `device_id`
+// is machine-stable, `session_id` is per process. `userInfo()` can throw in
+// locked-down sandboxes.
 let machineSeed: string
 try {
   machineSeed = `${hostname()}:${userInfo().username}:${homedir()}`

--- a/plugins/claude-oauth/src/system-prompt.ts
+++ b/plugins/claude-oauth/src/system-prompt.ts
@@ -1,39 +1,27 @@
 import { Array, pipe, String } from 'effect'
 
-// Paragraphs mentioning any of these are pi-internal (doc links, package ids)
-// and are dropped wholesale.
 const PI_REMOVAL_ANCHORS = [
   'pi-coding-agent',
   '@earendil-works/pi-coding-agent',
   'badlogic/pi-mono',
 ] as const
 
-// Pi's generated documentation section describes the harness, not Claude Code.
-// Drop the whole paragraph rather than relabeling it during the word rewrite.
 const PI_DOCUMENTATION_HEADING =
   'Pi documentation (read only when the user asks about pi itself,'
 
-// Rewrite "pi"/"Pi" only as a standalone word (the harness self-identification).
-// The lookbehind/lookahead spare it inside paths and identifiers (`/pi/`,
-// `pi-plugins`, `@pi`, `pi.mod`, `pi_x`, `pi:1`).
+// Standalone "pi"/"Pi" only; the lookarounds spare paths and identifiers
+// (`/pi/`, `pi-plugins`, `@pi`, `pi.mod`, `pi_x`, `pi:1`).
 const PI_WORD = /(?<![/\\.@:_-])\b[Pp]i\b(?![/\\.@:_-])/g
 
-function isPiInternalParagraph(paragraph: string): boolean {
-  return (
-    paragraph.toLowerCase().includes('you are pi') ||
-    paragraph.startsWith(PI_DOCUMENTATION_HEADING) ||
-    PI_REMOVAL_ANCHORS.some((anchor) => paragraph.includes(anchor))
-  )
-}
-
-/**
- * Drop pi-internal paragraphs, then rewrite the free-standing word "pi" to
- * "Claude Code". May return an empty string if every paragraph was pi-internal.
- */
 export function sanitizeSystemText(text: string): string {
   return pipe(
     text.split(/\n\n+/),
-    Array.filter((paragraph) => !isPiInternalParagraph(paragraph)),
+    Array.filter(
+      (paragraph) =>
+        !paragraph.toLowerCase().includes('you are pi') &&
+        !paragraph.startsWith(PI_DOCUMENTATION_HEADING) &&
+        !PI_REMOVAL_ANCHORS.some((anchor) => paragraph.includes(anchor)),
+    ),
     Array.join('\n\n'),
     String.replace(PI_WORD, 'Claude Code'),
     String.trim,

--- a/plugins/claude-oauth/src/utils.ts
+++ b/plugins/claude-oauth/src/utils.ts
@@ -19,7 +19,6 @@ const mergeRound = (acc: bigint, val: bigint): bigint => {
   return (((merged * PRIME64_1) & MASK) + PRIME64_4) & MASK
 }
 
-/** XXH64, used to reproduce Claude Code's `cch` request-integrity value. */
 export function xxHash64(input: Uint8Array, seed: bigint): bigint {
   const len = input.length
   const dv = new DataView(input.buffer, input.byteOffset, input.byteLength)
@@ -81,11 +80,9 @@ export function xxHash64(input: Uint8Array, seed: bigint): bigint {
 
 type TextBlock = { type: 'text'; text: string }
 
-/** Narrows an unknown content block to an Anthropic `{ type: 'text', text }` block. */
 export const isTextBlock = (u: unknown): u is TextBlock =>
   Predicate.isObject(u) && u['type'] === 'text' && Predicate.isString(u['text'])
 
-/** Concatenated text of the first user message — the seed for the billing header. */
 export function firstUserMessageText(
   messages: ReadonlyArray<{ role?: string; content?: unknown }>,
 ): string {

--- a/plugins/elapsed/src/index.ts
+++ b/plugins/elapsed/src/index.ts
@@ -1,14 +1,11 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 
-/** pi's own default working message, so the clock reads as an extension of it. */
-const WORKING_LABEL = 'Working...'
 const TICK_MS = 1000
 
 function pad(value: number): string {
   return value.toString().padStart(2, '0')
 }
 
-/** `4s`, `1m 04s`, `2h 07m 30s` — padded so the row keeps its width while counting. */
 export function formatElapsed(ms: number): string {
   const totalSeconds = Math.floor(ms / 1000)
   const seconds = totalSeconds % 60
@@ -37,7 +34,6 @@ export default function elapsed(pi: ExtensionAPI) {
   }
 
   pi.on('agent_start', (_event, ctx) => {
-    // Only the interactive loader renders a working message; elsewhere it is a no-op.
     if (ctx.mode !== 'tui') {
       return
     }
@@ -46,11 +42,10 @@ export default function elapsed(pi: ExtensionAPI) {
     const startedAt = performance.now()
     const show = () => {
       ctx.ui.setWorkingMessage(
-        `${WORKING_LABEL} ${formatElapsed(performance.now() - startedAt)}`,
+        `Working... ${formatElapsed(performance.now() - startedAt)}`,
       )
     }
 
-    // Each write repaints the loader, so the tick is what animates the clock.
     show()
     ticker = setInterval(show, TICK_MS)
     ticker.unref()

--- a/plugins/elapsed/src/index.ts
+++ b/plugins/elapsed/src/index.ts
@@ -1,5 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 
+// pi's own default working message, so the clock reads as an extension of it.
+const WORKING_LABEL = 'Working...'
 const TICK_MS = 1000
 
 function pad(value: number): string {
@@ -42,7 +44,7 @@ export default function elapsed(pi: ExtensionAPI) {
     const startedAt = performance.now()
     const show = () => {
       ctx.ui.setWorkingMessage(
-        `Working... ${formatElapsed(performance.now() - startedAt)}`,
+        `${WORKING_LABEL} ${formatElapsed(performance.now() - startedAt)}`,
       )
     }
 

--- a/plugins/fast-mode/src/index.ts
+++ b/plugins/fast-mode/src/index.ts
@@ -15,13 +15,11 @@ import {
 
 const EXTENSION_ID = 'fast-mode'
 const COMMAND_ARGS = ['on', 'off', 'status'] as const
-/** Status-line segment shown above the editor while fast mode is active. */
 const SEGMENT_KEY = EXTENSION_ID
 const SEGMENT_LABEL = '[fast mode]'
 
 const FastModeConfig = Schema.Struct({
   enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
-  /** `provider/model-id` keys that fast mode applies to. */
   models: Schema.Array(Schema.String).pipe(
     Schema.withDecodingDefault(
       Effect.succeed([
@@ -38,7 +36,6 @@ const FastModeConfig = Schema.Struct({
       ]),
     ),
   ),
-  /** Show a `fast mode` indicator above the editor while active. */
   showStatus: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
 })
 type FastModeConfig = typeof FastModeConfig.Type
@@ -46,20 +43,11 @@ type FastModeConfig = typeof FastModeConfig.Type
 type ActiveModel = NonNullable<ExtensionContext['model']>
 type FastModeApi = 'openai-responses' | 'openai-codex-responses'
 
-function modelKey(model: ActiveModel): string {
-  return `${model.provider}/${model.id}`
-}
-
-/**
- * Rewrites a provider request payload to ask for fast inference, returning the
- * replacement payload — or `undefined` to leave the request untouched.
- */
 type Applicator = (
   payload: Record<string, unknown>,
   model: ActiveModel,
 ) => Record<string, unknown> | undefined
 
-/** Whether fast mode can apply to the active model. */
 type Eligibility = Data.TaggedEnum<{
   Eligible: { readonly apply: Applicator }
   Ineligible: { readonly message: string }
@@ -74,7 +62,6 @@ const FAST_APPLICATORS: Record<string, Applicator> = {
 function applyOpenAIPriorityTier(
   payload: Record<string, unknown>,
 ): Record<string, unknown> | undefined {
-  // If the request already has a `service_tier`, leave it untouched.
   return Record.has(payload, 'service_tier')
     ? undefined
     : { ...payload, service_tier: 'priority' }
@@ -89,7 +76,7 @@ export default function fastMode(pi: ExtensionAPI) {
       return Eligibility.Ineligible({ message: 'no model is selected' })
     }
 
-    const key = modelKey(model)
+    const key = `${model.provider}/${model.id}`
     if (!config.models.includes(key)) {
       return Eligibility.Ineligible({
         message: `${key} is not in the configured models`,

--- a/plugins/speed/src/index.ts
+++ b/plugins/speed/src/index.ts
@@ -7,8 +7,6 @@ import { SpeedTracker } from './service'
 const SEGMENT_KEY = 'speed'
 
 export default function speed(pi: ExtensionAPI) {
-  // Plugin setup is synchronous. The shared run helpers cover only async
-  // boundaries.
   const tracker = Effect.runSync(SpeedTracker.make)
 
   function showWidget(ctx: ExtensionContext, text: string | undefined): void {
@@ -19,7 +17,6 @@ export default function speed(pi: ExtensionAPI) {
     )
   }
 
-  // Fires for every reason, including startup, where there is nothing to drop.
   pi.on('session_start', (_event, ctx) => {
     tracker.reset()
     showWidget(ctx, undefined)

--- a/plugins/speed/src/render.ts
+++ b/plugins/speed/src/render.ts
@@ -1,14 +1,5 @@
 import type { FirstToken, RecentSpeed } from './service'
 
-/**
- * Two significant figures. The standard error runs to a few percent, so past a
- * hundred tokens the last digit is below the noise and only reads as precision.
- */
-function formatTps(tps: number): string {
-  return `${tps < 100 ? Math.round(tps) : Math.round(tps / 10) * 10} tok/s`
-}
-
-/** "830ms", "1.24s", "27.3s", "94s" */
 function formatMs(ms: number): string {
   if (ms < 1000) {
     return `${Math.round(ms)}ms`
@@ -21,17 +12,17 @@ function formatMs(ms: number): string {
 }
 
 function recentTps(recent: RecentSpeed): string {
-  return `${recent.provisional ? '~' : ''}${formatTps(recent.tps)}`
+  // Two significant figures: the standard error is a few percent, so more digits
+  // would be noise.
+  const tps =
+    recent.tps < 100 ? Math.round(recent.tps) : Math.round(recent.tps / 10) * 10
+  return `${recent.provisional ? '~' : ''}${tps} tok/s`
 }
 
 export function recentText(recent: RecentSpeed): string {
   return `${recentTps(recent)} · TTFT ${formatMs(recent.ttftMs)}`
 }
 
-/**
- * Throughput stays on screen mid-stream because it describes the model, not the
- * in-flight request, and moves only once real token counts arrive.
- */
 export function streamingText(
   recent: RecentSpeed | undefined,
   firstToken: FirstToken,

--- a/plugins/speed/src/service.ts
+++ b/plugins/speed/src/service.ts
@@ -23,6 +23,7 @@ const UNSETTLED_RELATIVE_ERROR = 0.15
 // Bartlett lags for the serial-correlation term; past two the weights are noise.
 const HAC_LAGS = 2
 
+// A sample carrying the whole window leaves no residual to correct against.
 const MAX_LEVERAGE = 0.99
 
 // Share of billed reasoning the streamed thinking must cover to count as streamed
@@ -37,6 +38,7 @@ export type DeltaKind = 'thinking' | 'visible'
 
 interface Sample {
   readonly model: string
+  /** Monotonic: a wall clock can step backwards. */
   readonly recordedAt: number
   readonly ttftMs: number
   readonly generationMs: number
@@ -68,6 +70,60 @@ interface InflightRequest {
   firstDeltaChars: number
   visibleChars: number
   thinkingChars: number
+}
+
+// Splits total weight rather than count; `NaN` when empty.
+function weightedMedian(
+  entries: readonly { readonly value: number; readonly weight: number }[],
+): number {
+  const sorted = Array.sort(
+    entries,
+    Order.mapInput(Order.Number, (entry: (typeof entries)[number]) => entry.value),
+  )
+  const half = sorted.reduce((total, entry) => total + entry.weight, 0) / 2
+  let seen = 0
+  for (const entry of sorted) {
+    seen += entry.weight
+    if (seen >= half) {
+      return entry.value
+    }
+  }
+  return Number.NaN
+}
+
+// Reasoning is billed under `output` whether or not it streams. Withheld or
+// summarized thinking was produced before the first delta, so counting it would
+// credit work no measured interval covers (up to 2x too fast). Only the thinking
+// that streamed belongs in the numerator, converted back to tokens by this
+// request's visible chars-per-token.
+function streamedTokens(
+  request: InflightRequest,
+  outcome: RequestOutcome,
+): number | undefined {
+  const chars = request.visibleChars + request.thinkingChars
+  const withinInterval = chars - request.firstDeltaChars
+  if (withinInterval <= 0) {
+    return undefined
+  }
+
+  const reasoning = Math.min(outcome.reasoningTokens ?? 0, outcome.outputTokens)
+  const visible = outcome.outputTokens - reasoning
+  const density = visible > 0 ? request.visibleChars / visible : 0
+  const implied = density > 0 ? request.thinkingChars / density : 0
+  // Not clamped to `implied` on every request: that would charge density noise
+  // to models that stream their thinking in full.
+  const streamedReasoning =
+    density <= 0
+      ? request.thinkingChars > 0
+        ? reasoning
+        : 0
+      : implied >= reasoning * REASONING_STREAMED
+        ? reasoning
+        : implied
+
+  // The first delta predates the interval; its share is prorated out by
+  // characters since the opening chunk is routinely a fragment.
+  return ((visible + streamedReasoning) * withinInterval) / chars
 }
 
 // Tokens and milliseconds are summed separately and divided once, so a request
@@ -107,6 +163,7 @@ function recentSpeed(
     distance += sample.tokens
   }
 
+  // `latest` always matches and every sample clears MIN_OBSERVED_MS, so millis > 0.
   const rate = tokens / millis
 
   // Taylor-linearized variance of the ratio estimator. Each squared residual is
@@ -138,30 +195,13 @@ function recentSpeed(
   const relativeError = Math.sqrt(Math.max(variance, independent)) / tokens
   const effectiveSamples = 1 / leverageSquares
 
-  // Weighted median rather than latest: a retried request charges its whole
-  // backoff to TTFT.
-  const byTtft = Array.sort(
-    window,
-    Order.mapInput(
-      Order.Number,
-      (entry: (typeof window)[number]) => entry.sample.ttftMs,
-    ),
-  )
-  const halfWeight = byTtft.reduce((total, entry) => total + entry.weight, 0) / 2
-  let ttftMs = Number.NaN
-  let seen = 0
-  for (const entry of byTtft) {
-    seen += entry.weight
-    if (seen >= halfWeight) {
-      ttftMs = entry.sample.ttftMs
-      break
-    }
-  }
-
   return {
     model,
     tps: rate * 1000,
-    ttftMs,
+    // Median, not latest: a retried request charges its whole backoff to TTFT.
+    ttftMs: weightedMedian(
+      window.map((entry) => ({ value: entry.sample.ttftMs, weight: entry.weight })),
+    ),
     // The sample floor gates unconditionally: a window rebuilt from one request
     // fits it exactly, and its zero residual would hold the latch open on nothing.
     provisional: !(
@@ -227,6 +267,7 @@ export class SpeedTracker extends Context.Service<SpeedTracker>()(
           outcome.stopReason === 'aborted' ||
           outcome.outputTokens <= 0
         ) {
+          // A lone delta spans no interval; timing it would read as thousands of tok/s.
           return
         }
 
@@ -235,37 +276,8 @@ export class SpeedTracker extends Context.Service<SpeedTracker>()(
           return
         }
 
-        const chars = request.visibleChars + request.thinkingChars
-        const withinInterval = chars - request.firstDeltaChars
-        if (withinInterval <= 0) {
-          return
-        }
-
-        // Reasoning is billed under `output` whether or not it streams. Withheld
-        // or summarized thinking was produced before the first delta, so counting
-        // it would credit work no measured interval covers (up to 2x too fast).
-        // Only the thinking that streamed belongs in the numerator, converted
-        // back to tokens by this request's visible chars-per-token.
-        const reasoning = Math.min(
-          outcome.reasoningTokens ?? 0,
-          outcome.outputTokens,
-        )
-        const visible = outcome.outputTokens - reasoning
-        const density = visible > 0 ? request.visibleChars / visible : 0
-        const implied = density > 0 ? request.thinkingChars / density : 0
-        const streamedReasoning =
-          density <= 0
-            ? request.thinkingChars > 0
-              ? reasoning
-              : 0
-            : implied >= reasoning * REASONING_STREAMED
-              ? reasoning
-              : implied
-
-        // The first delta predates the interval; its share is prorated out by
-        // characters since the opening chunk is routinely a fragment.
-        const tokens = ((visible + streamedReasoning) * withinInterval) / chars
-        if (tokens <= 0) {
+        const tokens = streamedTokens(request, outcome)
+        if (tokens === undefined || tokens <= 0) {
           return
         }
 

--- a/plugins/speed/src/service.ts
+++ b/plugins/speed/src/service.ts
@@ -2,64 +2,44 @@ import { Array, Context, Effect, Order } from 'effect'
 
 const MAX_SAMPLES = 1000
 
-/**
- * Decay half-life of the live throughput estimate. In generated tokens rather
- * than requests, where a burst of tiny tool-call steps would flush a well-measured
- * estimate, or wall-clock, where the number would drift while the session idles.
- */
+// Decay in generated tokens, not requests (a burst of tiny tool-call steps would
+// flush a good estimate) or wall-clock (the number would drift while idle).
 const HALF_LIFE_TOKENS = 4000
 
 const MIN_WEIGHT = 1e-3
 
-/**
- * Ceiling on how old a sample may be. Token-space decay ages a model only while
- * that same model is generating, so a window left behind by a model switch — or
- * by an idle session — would otherwise still read as current hours later.
- */
+// Token-space decay only ages a model while it generates, so a window left behind
+// by a model switch or an idle session would otherwise read as current forever.
 const MAX_SAMPLE_AGE_MS = 30 * 60 * 1000
 
-/**
- * Effective sample size below which the error estimate is itself too noisy to act
- * on. Measured by leverage, not by request count: for a ratio, a window of twenty
- * tool-call steps beside one long answer is worth barely more than one
- * observation, and counting requests would call it twenty.
- */
+// Effective sample size by leverage, not request count: twenty tool-call steps
+// beside one long answer are worth barely more than one observation.
 const MIN_EFFECTIVE_SAMPLES = 5
 
-/** Hysteresis: one threshold flickered as heavy requests left the window. */
+// Hysteresis: a single threshold flickered as heavy requests left the window.
 const SETTLED_RELATIVE_ERROR = 0.05
 const UNSETTLED_RELATIVE_ERROR = 0.15
 
-/** Bartlett lags for the serial-correlation term. Past two the weights are noise. */
+// Bartlett lags for the serial-correlation term; past two the weights are noise.
 const HAC_LAGS = 2
 
-/** A sample carrying the whole window leaves no residual to correct against. */
 const MAX_LEVERAGE = 0.99
 
-/**
- * Share of the billed reasoning the streamed thinking must account for before it
- * counts as having streamed whole. Characters per token swings by a fifth or so
- * between prose, code and JSON, and comparing the two sides of one request
- * compounds that; anything under this gap is a summary, not measurement noise.
- */
+// Share of billed reasoning the streamed thinking must cover to count as streamed
+// whole. Chars-per-token varies ~20% between prose, code and JSON; anything under
+// this gap is a summary, not measurement noise.
 const REASONING_STREAMED = 0.6
 
-/**
- * Below this the chunks were flushed from a buffer, not generated. A floor in ms
- * rather than a ceiling on implied rate, which would truncate the fast tail.
- */
+// Below this the chunks were flushed from a buffer, not generated.
 const MIN_OBSERVED_MS = 2
 
 export type DeltaKind = 'thinking' | 'visible'
 
 interface Sample {
   readonly model: string
-  /** Monotonic, for the staleness horizon only; a wall clock can step backwards. */
   readonly recordedAt: number
   readonly ttftMs: number
-  /** First delta to last delta; provider teardown falls outside. */
   readonly generationMs: number
-  /** Billed tokens shown to have crossed the wire within `generationMs`. */
   readonly tokens: number
 }
 
@@ -67,7 +47,6 @@ export interface RecentSpeed {
   readonly model: string
   readonly tps: number
   readonly ttftMs: number
-  /** The spread across recent requests is still too wide to stand behind. */
   readonly provisional: boolean
 }
 
@@ -79,7 +58,6 @@ export interface RequestOutcome {
   readonly model: string
   readonly stopReason: string
   readonly outputTokens: number
-  /** A subset of `outputTokens`; undefined where the provider reports no split. */
   readonly reasoningTokens: number | undefined
 }
 
@@ -92,78 +70,9 @@ interface InflightRequest {
   thinkingChars: number
 }
 
-interface WeightedValue {
-  readonly value: number
-  readonly weight: number
-}
-
-/** Median that splits total weight rather than count; `NaN` when empty. */
-function weightedMedian(entries: readonly WeightedValue[]): number {
-  const sorted = Array.sort(
-    entries,
-    Order.mapInput(Order.Number, (entry: WeightedValue) => entry.value),
-  )
-  const half = sorted.reduce((total, entry) => total + entry.weight, 0) / 2
-  let seen = 0
-  for (const entry of sorted) {
-    seen += entry.weight
-    if (seen >= half) {
-      return entry.value
-    }
-  }
-  return Number.NaN
-}
-
-/**
- * The billed tokens this stream can account for, narrowed to the ones that arrived
- * inside the measured interval.
- *
- * Reasoning is billed under `output` whether or not the provider streams it. Where
- * it is withheld, or cut down to a summary, the time that produced it lands before
- * the first delta, so counting those tokens here credits the model with work no
- * measured interval covers — enough to read half again to twice too fast. Only the
- * thinking that actually streamed belongs in the numerator, and characters per
- * token, taken from the visible content of this same request, is what converts it
- * back into tokens.
- */
-function streamedTokens(
-  request: InflightRequest,
-  outcome: RequestOutcome,
-): number | undefined {
-  const chars = request.visibleChars + request.thinkingChars
-  const withinInterval = chars - request.firstDeltaChars
-  if (withinInterval <= 0) {
-    return undefined
-  }
-
-  const reasoning = Math.min(outcome.reasoningTokens ?? 0, outcome.outputTokens)
-  const visible = outcome.outputTokens - reasoning
-  const density = visible > 0 ? request.visibleChars / visible : 0
-  // Clamping to the implied count on every request would charge the density noise
-  // to models that stream their thinking in full, which is measurable, and add
-  // spread the estimate has no reason to carry.
-  const implied = density > 0 ? request.thinkingChars / density : 0
-  const streamedReasoning =
-    density <= 0
-      ? request.thinkingChars > 0
-        ? reasoning
-        : 0
-      : implied >= reasoning * REASONING_STREAMED
-        ? reasoning
-        : implied
-
-  // The first delta predates the interval, so its share is dropped. Prorated by
-  // characters rather than by chunk count, which assumed every chunk was equal
-  // when the opening one is routinely a fragment.
-  return ((visible + streamedReasoning) * withinInterval) / chars
-}
-
-/**
- * Tokens and milliseconds are summed separately and divided once, so a request
- * counts in proportion to the evidence it carries. Averaging per-request rates
- * instead would give a 30-token tool-call step — mostly fixed per-request
- * overhead — the same say as a 1500-token answer.
- */
+// Tokens and milliseconds are summed separately and divided once, so a request
+// counts in proportion to its evidence. Averaging per-request rates would give a
+// 30-token tool-call step the same say as a 1500-token answer.
 function recentSpeed(
   samples: readonly Sample[],
   settled: boolean,
@@ -173,8 +82,6 @@ function recentSpeed(
     return undefined
   }
 
-  // Only the model that answered last: blending two models' rate curves would
-  // describe neither.
   const model = latest.model
   const horizon = latest.recordedAt - MAX_SAMPLE_AGE_MS
   const window: { readonly weight: number; readonly sample: Sample }[] = []
@@ -200,13 +107,11 @@ function recentSpeed(
     distance += sample.tokens
   }
 
-  // `latest` always matches and every sample clears MIN_OBSERVED_MS, so millis > 0.
   const rate = tokens / millis
 
   // Taylor-linearized variance of the ratio estimator. Each squared residual is
-  // divided by its own leverage: a request holding half the window's time is half
-  // of what it is being compared against, and left uncorrected it fits itself and
-  // reports a precision the window does not have.
+  // divided by its own leverage: a request holding half the window's time is
+  // half of what it is compared against and would otherwise fit itself.
   let independent = 0
   let leverageSquares = 0
   const scores: number[] = []
@@ -218,10 +123,9 @@ function recentSpeed(
     scores.push(score)
   }
 
-  // Requests in one turn share a provider node, a queue position and a context
-  // length, so their residuals move together and the independent sum reads far
-  // too small. Bartlett-weighted lags add that covariance back; the kernel can
-  // come out negative under alternation, hence the floor.
+  // Requests in one turn share a provider node, queue position and context
+  // length, so their residuals move together. Bartlett-weighted lags add that
+  // covariance back; the kernel can go negative under alternation, hence the floor.
   let variance = independent
   for (let lag = 1; lag <= HAC_LAGS; lag++) {
     let covariance = 0
@@ -234,16 +138,32 @@ function recentSpeed(
   const relativeError = Math.sqrt(Math.max(variance, independent)) / tokens
   const effectiveSamples = 1 / leverageSquares
 
+  // Weighted median rather than latest: a retried request charges its whole
+  // backoff to TTFT.
+  const byTtft = Array.sort(
+    window,
+    Order.mapInput(
+      Order.Number,
+      (entry: (typeof window)[number]) => entry.sample.ttftMs,
+    ),
+  )
+  const halfWeight = byTtft.reduce((total, entry) => total + entry.weight, 0) / 2
+  let ttftMs = Number.NaN
+  let seen = 0
+  for (const entry of byTtft) {
+    seen += entry.weight
+    if (seen >= halfWeight) {
+      ttftMs = entry.sample.ttftMs
+      break
+    }
+  }
+
   return {
     model,
     tps: rate * 1000,
-    // Median, not latest: a retried request charges its whole backoff to TTFT.
-    ttftMs: weightedMedian(
-      window.map((entry) => ({ value: entry.sample.ttftMs, weight: entry.weight })),
-    ),
-    // The sample floor gates unconditionally rather than on the way in only: a
-    // window rebuilt from one request fits it exactly, leaving a zero residual
-    // that reads as perfect precision and would hold the latch open on nothing.
+    ttftMs,
+    // The sample floor gates unconditionally: a window rebuilt from one request
+    // fits it exactly, and its zero residual would hold the latch open on nothing.
     provisional: !(
       effectiveSamples >= MIN_EFFECTIVE_SAMPLES &&
       relativeError <= (settled ? UNSETTLED_RELATIVE_ERROR : SETTLED_RELATIVE_ERROR)
@@ -251,10 +171,6 @@ function recentSpeed(
   }
 }
 
-/**
- * Tracks inference speed across one session: measures the in-flight provider
- * request and accumulates completed requests into a bounded sample window.
- */
 export class SpeedTracker extends Context.Service<SpeedTracker>()(
   '@pi-plugins/speed/SpeedTracker',
   {
@@ -263,12 +179,9 @@ export class SpeedTracker extends Context.Service<SpeedTracker>()(
       let inflight: InflightRequest | undefined
       let settled = false
 
-      /**
-       * Compaction and branch summarization stream through this hook too without
-       * surfacing as assistant messages, so one can fire mid-turn and must not
-       * re-anchor a request already streaming.
-       */
       function beginRequest(): void {
+        // Compaction and branch summarization stream through this hook too, so
+        // one can fire mid-turn and must not re-anchor a request already streaming.
         if (inflight?.firstTokenAt !== undefined) {
           return
         }
@@ -280,10 +193,6 @@ export class SpeedTracker extends Context.Service<SpeedTracker>()(
         }
       }
 
-      /**
-       * Returns the measured TTFT exactly once, on the first delta. Tokens/sec is
-       * never estimated mid-stream: real token counts arrive only at message end.
-       */
       function recordDelta(kind: DeltaKind, length: number): FirstToken | undefined {
         const request = inflight
         if (request === undefined) {
@@ -318,8 +227,6 @@ export class SpeedTracker extends Context.Service<SpeedTracker>()(
           outcome.stopReason === 'aborted' ||
           outcome.outputTokens <= 0
         ) {
-          // Nothing measurable or an interrupted stream. A lone delta spans no
-          // interval at all, and timing it would read as thousands of tokens/sec.
           return
         }
 
@@ -328,8 +235,37 @@ export class SpeedTracker extends Context.Service<SpeedTracker>()(
           return
         }
 
-        const tokens = streamedTokens(request, outcome)
-        if (tokens === undefined || tokens <= 0) {
+        const chars = request.visibleChars + request.thinkingChars
+        const withinInterval = chars - request.firstDeltaChars
+        if (withinInterval <= 0) {
+          return
+        }
+
+        // Reasoning is billed under `output` whether or not it streams. Withheld
+        // or summarized thinking was produced before the first delta, so counting
+        // it would credit work no measured interval covers (up to 2x too fast).
+        // Only the thinking that streamed belongs in the numerator, converted
+        // back to tokens by this request's visible chars-per-token.
+        const reasoning = Math.min(
+          outcome.reasoningTokens ?? 0,
+          outcome.outputTokens,
+        )
+        const visible = outcome.outputTokens - reasoning
+        const density = visible > 0 ? request.visibleChars / visible : 0
+        const implied = density > 0 ? request.thinkingChars / density : 0
+        const streamedReasoning =
+          density <= 0
+            ? request.thinkingChars > 0
+              ? reasoning
+              : 0
+            : implied >= reasoning * REASONING_STREAMED
+              ? reasoning
+              : implied
+
+        // The first delta predates the interval; its share is prorated out by
+        // characters since the opening chunk is routinely a fragment.
+        const tokens = ((visible + streamedReasoning) * withinInterval) / chars
+        if (tokens <= 0) {
           return
         }
 
@@ -341,16 +277,10 @@ export class SpeedTracker extends Context.Service<SpeedTracker>()(
           tokens,
         })
         if (samples.length >= MAX_SAMPLES * 2) {
-          // Amortized trim: let the buffer grow to twice the window, then cut
-          // back in one splice instead of shifting on every append.
           samples.splice(0, samples.length - MAX_SAMPLES)
         }
       }
 
-      /**
-       * Advances the settled latch. Idempotent for a given window: a rate that
-       * just cleared the settling bar cannot exceed the wider un-settling one.
-       */
       function recent(): RecentSpeed | undefined {
         const speed = recentSpeed(samples, settled)
         settled = speed !== undefined && !speed.provisional

--- a/plugins/subagent/src/index.ts
+++ b/plugins/subagent/src/index.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import { getAgentDir } from '@earendil-works/pi-coding-agent'
 import { Text } from '@earendil-works/pi-tui'
 import * as NodeServices from '@effect/platform-node/NodeServices'
 import { runTool } from '@pi-plugins/shared/run'
@@ -12,15 +13,9 @@ import {
   type SubagentResult,
   type SubagentUsage,
 } from './runner'
-import {
-  capToolOutput,
-  formatStats,
-  modelPattern,
-  subagentSessionDir,
-} from './utils'
+import { capToolOutput, formatStats } from './utils'
 
-// Wrapped terminal rows, not source lines, so a row's height is bounded whatever
-// the prompt and the output happen to be shaped like.
+// Wrapped terminal rows, not source lines, so a row's height stays bounded.
 const PROMPT_PREVIEW_LINES = 3
 const OUTPUT_PREVIEW_LINES = 5
 const METADATA_LABEL_WIDTH = 9
@@ -51,7 +46,6 @@ export type SubagentInput = Static<typeof subagentSchema>
 interface SubagentDetails extends SubagentResult {
   cwd?: string | undefined
   model?: string | undefined
-  /** Set on the final result when the run failed. */
   failed?: boolean | undefined
   errorMessage?: string | undefined
   stderr?: string | undefined
@@ -60,8 +54,9 @@ interface SubagentDetails extends SubagentResult {
 export default function subagent(pi: ExtensionAPI) {
   const pending: SubagentUsage[] = []
 
-  // Fold subagent cost back into the parent session so the footer's cumulative
-  // cost includes delegated work.
+  // Folds subagent cost into the parent session so the footer's cumulative cost
+  // includes delegated work. Only `cost.total`: the token fields feed pi's
+  // auto-compaction heuristics and must stay untouched.
   pi.on('message_end', ({ message }) => {
     if (
       message.role !== 'assistant' ||
@@ -72,9 +67,6 @@ export default function subagent(pi: ExtensionAPI) {
     }
     const cost = { ...message.usage.cost }
     for (const run of pending.splice(0)) {
-      // Only `cost.total` is folded. The per-request token fields (input, output,
-      // cacheRead, cacheWrite) must stay untouched as they are used by pi's auto-compaction heuristics.
-      // Cost is only ever summed for display, so it is safe to fold.
       cost.total += run.cost
     }
     return { message: { ...message, usage: { ...message.usage, cost } } }
@@ -92,26 +84,26 @@ export default function subagent(pi: ExtensionAPI) {
       'Delegate self-contained tasks to subagents (isolated headless pi instances).',
     parameters: subagentSchema,
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
-      // An omitted `model` should mean "same model", not "child default".
       const model =
         params.model ??
-        (ctx.model !== undefined
-          ? modelPattern(ctx.model, pi.getThinkingLevel())
-          : undefined)
+        (ctx.model === undefined
+          ? undefined
+          : `${ctx.model.provider}/${ctx.model.id}:${pi.getThinkingLevel()}`)
 
-      // Resolve relative cwd against the parent session's cwd, not the process
-      // cwd (they can differ for resumed/cross-project sessions).
+      // Relative to the parent session's cwd, not the process cwd: they differ
+      // for resumed and cross-project sessions.
       const cwd =
         params.cwd !== undefined ? path.resolve(ctx.cwd, params.cwd) : ctx.cwd
 
-      // Inherit the parent's active tool set (minus subagent itself) so a
-      // restricted parent (e.g. `pi --tools read`) cannot be escaped by
-      // delegating to a child with default tools.
+      // Inheriting the parent's tool set keeps a restricted parent (e.g.
+      // `pi --tools read`) from being escaped through a child with default tools.
       const tools = pi.getActiveTools().filter((name) => name !== 'subagent')
 
       const program = runSubagent({
         prompt: params.prompt,
-        sessionDir: subagentSessionDir(),
+        // Beside pi's per-project `--<cwd>--` directories, so child sessions stay
+        // out of `pi -c` / `pi -r` but resolve by id from anywhere.
+        sessionDir: path.join(getAgentDir(), 'sessions', 'subagents'),
         name: params.description,
         model,
         cwd,
@@ -211,7 +203,6 @@ export default function subagent(pi: ExtensionAPI) {
         )
         .join('\n')
 
-      // No status line while running: the pending background tint is the indicator.
       if (isPartial) {
         return new Text(metadataBlock ? `\n${metadataBlock}` : '', 0, 0)
       }
@@ -229,15 +220,12 @@ export default function subagent(pi: ExtensionAPI) {
         '(no output)'
 
       let header = metadataBlock ? `\n${metadataBlock}\n\n${status}` : `\n${status}`
-      // Skip the error line when it would repeat the rendered content.
       if (failed && details.errorMessage && details.errorMessage !== content) {
         header += `\n${theme.fg('error', `Error: ${details.errorMessage}`)}`
       }
 
       return new ExpandableText({
         header,
-        // Keep the full output in details for explicit expansion, but bound what
-        // the collapsed row has to wrap to pi's standard tool-output limits.
         content: expanded ? content : capToolOutput(content),
         maxLines: OUTPUT_PREVIEW_LINES,
         expanded,

--- a/plugins/subagent/src/runner.ts
+++ b/plugins/subagent/src/runner.ts
@@ -4,13 +4,9 @@ import { Data, Effect, Fiber, Filter, Schema, Stream } from 'effect'
 import type { PlatformError } from 'effect/PlatformError'
 import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
 
-/** Cap on buffered stderr (in characters) so a pathological child can't exhaust memory. */
 const STDERR_CAP = 50 * 1024
-
-/** Grace period between SIGTERM and SIGKILL when terminating the child. */
 const FORCE_KILL_AFTER = '5 seconds'
 
-/** Aggregated token/cost statistics across all turns of a subagent run. */
 export interface SubagentUsage {
   turns: number
   input: number
@@ -21,7 +17,6 @@ export interface SubagentUsage {
   contextTokens: number
 }
 
-/** What a run produced; errors carry the partial result of the work done so far. */
 export interface SubagentResult {
   output: string
   toolCalls: number
@@ -44,13 +39,8 @@ export const emptyResult: SubagentResult = {
   },
 }
 
-/**
- * The subagent stopped without completing its task: the child reported an
- * `error` or `aborted` stop reason on its final assistant message.
- */
 export class SubagentStopError extends Data.TaggedError('SubagentStopError')<{
   readonly reason: 'error' | 'aborted'
-  /** Error detail reported by the child, if any. */
   readonly errorMessage?: string | undefined
   readonly stderr: string
   readonly result: SubagentResult
@@ -62,7 +52,6 @@ export class SubagentStopError extends Data.TaggedError('SubagentStopError')<{
     `run stopped (${this.reason})`
 }
 
-/** The pi child process exited with a nonzero exit code. */
 export class SubagentExitError extends Data.TaggedError('SubagentExitError')<{
   readonly exitCode: number
   readonly stderr: string
@@ -74,11 +63,6 @@ export class SubagentExitError extends Data.TaggedError('SubagentExitError')<{
     `pi exited with code ${this.exitCode}`
 }
 
-/**
- * The child exited cleanly but emitted no assistant messages, meaning it
- * produced no usable output (wrong invocation, polluted stdout, JSON format
- * drift, ...).
- */
 export class SubagentNoOutputError extends Data.TaggedError(
   'SubagentNoOutputError',
 )<{
@@ -90,7 +74,6 @@ export class SubagentNoOutputError extends Data.TaggedError(
     (this.stderr.trim() ? `\nstderr: ${this.stderr.trim()}` : '')
 }
 
-/** The header pi prints as the first line of a `--mode json` stream. */
 const SessionHeader = Schema.Struct({
   type: Schema.Literal('session'),
   id: Schema.String,
@@ -123,90 +106,16 @@ const AssistantMessageEnd = Schema.Struct({
   }),
 })
 
-/**
- * The `--mode json` event lines we care about (see pi docs/json.md): the
- * session header and completed assistant messages.
- */
 const SubagentEvent = Schema.fromJsonString(
   Schema.Union([SessionHeader, AssistantMessageEnd]),
 )
 
-type AssistantMessage = (typeof AssistantMessageEnd)['Type']['message']
-
-/** Fold state: the public result plus the child's last reported stop info. */
 interface RunState {
   result: SubagentResult
   stopReason?: string | undefined
   errorMessage?: string | undefined
 }
 
-const initialState: RunState = { result: emptyResult }
-
-/** Folds one completed assistant message into the run state. */
-function foldMessage(state: RunState, message: AssistantMessage): RunState {
-  const { result } = state
-  let toolCalls = result.toolCalls
-  const texts: string[] = []
-  for (const part of message.content) {
-    if (part.type === 'text' && part.text !== undefined) {
-      texts.push(part.text)
-    } else if (part.type === 'toolCall') {
-      toolCalls += 1
-    }
-  }
-  const text = texts.join('\n\n').trim()
-  const output = text.length > 0 ? text : result.output
-
-  const usage = message.usage
-  return {
-    result: {
-      ...result,
-      output,
-      toolCalls,
-      usage: {
-        turns: result.usage.turns + 1,
-        input: result.usage.input + (usage?.input ?? 0),
-        output: result.usage.output + (usage?.output ?? 0),
-        cacheRead: result.usage.cacheRead + (usage?.cacheRead ?? 0),
-        cacheWrite: result.usage.cacheWrite + (usage?.cacheWrite ?? 0),
-        cost: result.usage.cost + (usage?.cost?.total ?? 0),
-        contextTokens: usage?.totalTokens ?? result.usage.contextTokens,
-      },
-    },
-    stopReason: message.stopReason ?? state.stopReason,
-    errorMessage: message.errorMessage ?? state.errorMessage,
-  }
-}
-
-/**
- * Resolves how to re-invoke the running pi harness: the current entry script
- * via the current runtime, the executable itself (compiled binaries), or
- * `pi` on PATH.
- */
-function resolvePiInvocation(args: ReadonlyArray<string>): {
-  command: string
-  args: ReadonlyArray<string>
-} {
-  const currentScript = process.argv[1]
-  const isBunVirtualScript = currentScript?.startsWith('/$bunfs/root/')
-  if (currentScript && !isBunVirtualScript && fs.existsSync(currentScript)) {
-    return { command: process.execPath, args: [currentScript, ...args] }
-  }
-
-  const execName = path.basename(process.execPath).toLowerCase()
-  const isGenericRuntime = /^(node|bun)(\.exe)?$/.test(execName)
-  if (!isGenericRuntime) {
-    return { command: process.execPath, args }
-  }
-
-  return { command: 'pi', args }
-}
-
-/**
- * Runs one headless pi instance for the given prompt and folds its JSONL
- * event stream into a `SubagentResult`. `onSession` fires once, when the child
- * reports the id of the session it persists to.
- */
 export function runSubagent(options: {
   prompt: string
   sessionDir: string
@@ -222,8 +131,7 @@ export function runSubagent(options: {
 > {
   return Effect.scoped(
     Effect.gen(function* () {
-      // `--exclude-tools subagent` prevents children from recursively
-      // spawning their own subagents.
+      // `--exclude-tools subagent` keeps children from spawning their own.
       const args = [
         '--mode',
         'json',
@@ -238,8 +146,6 @@ export function runSubagent(options: {
       if (name) {
         args.push('--name', name)
       }
-      // Inherit the parent's active tool set so a restricted parent
-      // (e.g. `--tools read`) cannot be escaped through the child.
       if (options.tools !== undefined) {
         if (options.tools.length > 0) {
           args.push('--tools', options.tools.join(','))
@@ -250,21 +156,29 @@ export function runSubagent(options: {
       if (options.model !== undefined) {
         args.push('--model', options.model)
       }
-      const invocation = resolvePiInvocation(args)
+
+      // Re-invoke the running harness: the entry script via the current runtime,
+      // the executable itself for compiled binaries, or `pi` on PATH.
+      const currentScript = process.argv[1]
+      const isBunVirtualScript = currentScript?.startsWith('/$bunfs/root/')
+      const execName = path.basename(process.execPath).toLowerCase()
+      const invocation =
+        currentScript && !isBunVirtualScript && fs.existsSync(currentScript)
+          ? { command: process.execPath, args: [currentScript, ...args] }
+          : /^(node|bun)(\.exe)?$/.test(execName)
+            ? { command: 'pi', args }
+            : { command: process.execPath, args }
+
       const startedAt = Date.now()
-      const handle = yield* ChildProcess.make(
-        invocation.command,
-        [...invocation.args],
-        {
-          cwd: options.cwd,
-          // Override a process-wide long retention setting. The explicit short
-          // value also tells @pi-plugins/claude-oauth not to extend child TTLs.
-          env: { PI_CACHE_RETENTION: 'short' },
-          extendEnv: true,
-          stdin: Stream.make(new TextEncoder().encode(options.prompt)),
-          forceKillAfter: FORCE_KILL_AFTER,
-        },
-      )
+      const handle = yield* ChildProcess.make(invocation.command, invocation.args, {
+        cwd: options.cwd,
+        // Overrides a process-wide long retention setting; the explicit value
+        // also tells @pi-plugins/claude-oauth not to extend child TTLs.
+        env: { PI_CACHE_RETENTION: 'short' },
+        extendEnv: true,
+        stdin: Stream.make(new TextEncoder().encode(options.prompt)),
+        forceKillAfter: FORCE_KILL_AFTER,
+      })
 
       const stderrFiber = yield* Effect.forkScoped(
         handle.stderr.pipe(
@@ -286,7 +200,7 @@ export function runSubagent(options: {
           Filter.fromPredicateOption(Schema.decodeUnknownOption(SubagentEvent)),
         ),
         Stream.runFoldEffect(
-          () => initialState,
+          (): RunState => ({ result: emptyResult }),
           (previous, event) =>
             Effect.sync(() => {
               if (event.type === 'session') {
@@ -300,7 +214,38 @@ export function runSubagent(options: {
                   result: { ...previous.result, sessionId: event.id },
                 }
               }
-              return foldMessage(previous, event.message)
+
+              const { result } = previous
+              const { message } = event
+              let toolCalls = result.toolCalls
+              const texts: string[] = []
+              for (const part of message.content) {
+                if (part.type === 'text' && part.text !== undefined) {
+                  texts.push(part.text)
+                } else if (part.type === 'toolCall') {
+                  toolCalls += 1
+                }
+              }
+              const text = texts.join('\n\n').trim()
+              const usage = message.usage
+              return {
+                result: {
+                  ...result,
+                  output: text.length > 0 ? text : result.output,
+                  toolCalls,
+                  usage: {
+                    turns: result.usage.turns + 1,
+                    input: result.usage.input + (usage?.input ?? 0),
+                    output: result.usage.output + (usage?.output ?? 0),
+                    cacheRead: result.usage.cacheRead + (usage?.cacheRead ?? 0),
+                    cacheWrite: result.usage.cacheWrite + (usage?.cacheWrite ?? 0),
+                    cost: result.usage.cost + (usage?.cost?.total ?? 0),
+                    contextTokens: usage?.totalTokens ?? result.usage.contextTokens,
+                  },
+                },
+                stopReason: message.stopReason ?? previous.stopReason,
+                errorMessage: message.errorMessage ?? previous.errorMessage,
+              }
             }),
         ),
       )

--- a/plugins/subagent/src/runner.ts
+++ b/plugins/subagent/src/runner.ts
@@ -116,6 +116,42 @@ interface RunState {
   errorMessage?: string | undefined
 }
 
+function foldMessage(
+  state: RunState,
+  message: (typeof AssistantMessageEnd)['Type']['message'],
+): RunState {
+  const { result } = state
+  let toolCalls = result.toolCalls
+  const texts: string[] = []
+  for (const part of message.content) {
+    if (part.type === 'text' && part.text !== undefined) {
+      texts.push(part.text)
+    } else if (part.type === 'toolCall') {
+      toolCalls += 1
+    }
+  }
+  const text = texts.join('\n\n').trim()
+  const usage = message.usage
+  return {
+    result: {
+      ...result,
+      output: text.length > 0 ? text : result.output,
+      toolCalls,
+      usage: {
+        turns: result.usage.turns + 1,
+        input: result.usage.input + (usage?.input ?? 0),
+        output: result.usage.output + (usage?.output ?? 0),
+        cacheRead: result.usage.cacheRead + (usage?.cacheRead ?? 0),
+        cacheWrite: result.usage.cacheWrite + (usage?.cacheWrite ?? 0),
+        cost: result.usage.cost + (usage?.cost?.total ?? 0),
+        contextTokens: usage?.totalTokens ?? result.usage.contextTokens,
+      },
+    },
+    stopReason: message.stopReason ?? state.stopReason,
+    errorMessage: message.errorMessage ?? state.errorMessage,
+  }
+}
+
 export function runSubagent(options: {
   prompt: string
   sessionDir: string
@@ -214,38 +250,7 @@ export function runSubagent(options: {
                   result: { ...previous.result, sessionId: event.id },
                 }
               }
-
-              const { result } = previous
-              const { message } = event
-              let toolCalls = result.toolCalls
-              const texts: string[] = []
-              for (const part of message.content) {
-                if (part.type === 'text' && part.text !== undefined) {
-                  texts.push(part.text)
-                } else if (part.type === 'toolCall') {
-                  toolCalls += 1
-                }
-              }
-              const text = texts.join('\n\n').trim()
-              const usage = message.usage
-              return {
-                result: {
-                  ...result,
-                  output: text.length > 0 ? text : result.output,
-                  toolCalls,
-                  usage: {
-                    turns: result.usage.turns + 1,
-                    input: result.usage.input + (usage?.input ?? 0),
-                    output: result.usage.output + (usage?.output ?? 0),
-                    cacheRead: result.usage.cacheRead + (usage?.cacheRead ?? 0),
-                    cacheWrite: result.usage.cacheWrite + (usage?.cacheWrite ?? 0),
-                    cost: result.usage.cost + (usage?.cost?.total ?? 0),
-                    contextTokens: usage?.totalTokens ?? result.usage.contextTokens,
-                  },
-                },
-                stopReason: message.stopReason ?? previous.stopReason,
-                errorMessage: message.errorMessage ?? previous.errorMessage,
-              }
+              return foldMessage(previous, event.message)
             }),
         ),
       )

--- a/plugins/subagent/src/utils.ts
+++ b/plugins/subagent/src/utils.ts
@@ -22,6 +22,19 @@ function formatTokens(count: number): string {
   return `${(count / 1000000).toFixed(1)}M`
 }
 
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000)
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`
+  }
+  const seconds = `${totalSeconds % 60}`.padStart(2, '0')
+  const minutes = Math.floor(totalSeconds / 60) % 60
+  const hours = Math.floor(totalSeconds / 3600)
+  return hours > 0
+    ? `${hours}h${`${minutes}`.padStart(2, '0')}m${seconds}s`
+    : `${minutes}m${seconds}s`
+}
+
 export function formatStats(result: SubagentResult): string {
   const { usage, toolCalls } = result
   const parts: string[] = []
@@ -47,19 +60,7 @@ export function formatStats(result: SubagentResult): string {
     parts.push(`$${usage.cost.toFixed(4)}`)
   }
   if (result.durationMs !== undefined) {
-    const totalSeconds = Math.round(result.durationMs / 1000)
-    if (totalSeconds < 60) {
-      parts.push(`${totalSeconds}s`)
-    } else {
-      const seconds = `${totalSeconds % 60}`.padStart(2, '0')
-      const minutes = Math.floor(totalSeconds / 60) % 60
-      const hours = Math.floor(totalSeconds / 3600)
-      parts.push(
-        hours > 0
-          ? `${hours}h${`${minutes}`.padStart(2, '0')}m${seconds}s`
-          : `${minutes}m${seconds}s`,
-      )
-    }
+    parts.push(formatDuration(result.durationMs))
   }
   return parts.join(' ')
 }

--- a/plugins/subagent/src/utils.ts
+++ b/plugins/subagent/src/utils.ts
@@ -1,17 +1,7 @@
-import * as path from 'node:path'
-import { getAgentDir, truncateHead } from '@earendil-works/pi-coding-agent'
+import { truncateHead } from '@earendil-works/pi-coding-agent'
 import { formatTruncationNotice } from '@pi-plugins/shared/ui'
 import type { SubagentResult } from './runner'
 
-/**
- * Beside pi's per-project session directories, which are always `--<cwd>--`, so
- * child sessions stay out of `pi -c` / `pi -r` but resolve by id from anywhere.
- */
-export function subagentSessionDir(): string {
-  return path.join(getAgentDir(), 'sessions', 'subagents')
-}
-
-/** Caps text to pi's standard tool-output limits, appending a notice when truncated. */
 export function capToolOutput(text: string): string {
   const truncation = truncateHead(text)
   return truncation.truncated
@@ -19,8 +9,7 @@ export function capToolOutput(text: string): string {
     : truncation.content
 }
 
-/** Formats a token count compactly (e.g. `950`, `1.2k`, `45k`, `1.3M`). */
-export function formatTokens(count: number): string {
+function formatTokens(count: number): string {
   if (count < 1000) {
     return count.toString()
   }
@@ -33,22 +22,6 @@ export function formatTokens(count: number): string {
   return `${(count / 1000000).toFixed(1)}M`
 }
 
-/** Formats a duration compactly (e.g. `9s`, `1m22s`, `2h07m30s`). */
-function formatDuration(ms: number): string {
-  const totalSeconds = Math.round(ms / 1000)
-  if (totalSeconds < 60) {
-    return `${totalSeconds}s`
-  }
-
-  const seconds = `${totalSeconds % 60}`.padStart(2, '0')
-  const minutes = Math.floor(totalSeconds / 60) % 60
-  const hours = Math.floor(totalSeconds / 3600)
-  return hours > 0
-    ? `${hours}h${`${minutes}`.padStart(2, '0')}m${seconds}s`
-    : `${minutes}m${seconds}s`
-}
-
-/** Formats a finished run as one line: turns, tools, tokens, cost, duration. */
 export function formatStats(result: SubagentResult): string {
   const { usage, toolCalls } = result
   const parts: string[] = []
@@ -74,16 +47,19 @@ export function formatStats(result: SubagentResult): string {
     parts.push(`$${usage.cost.toFixed(4)}`)
   }
   if (result.durationMs !== undefined) {
-    parts.push(formatDuration(result.durationMs))
+    const totalSeconds = Math.round(result.durationMs / 1000)
+    if (totalSeconds < 60) {
+      parts.push(`${totalSeconds}s`)
+    } else {
+      const seconds = `${totalSeconds % 60}`.padStart(2, '0')
+      const minutes = Math.floor(totalSeconds / 60) % 60
+      const hours = Math.floor(totalSeconds / 3600)
+      parts.push(
+        hours > 0
+          ? `${hours}h${`${minutes}`.padStart(2, '0')}m${seconds}s`
+          : `${minutes}m${seconds}s`,
+      )
+    }
   }
   return parts.join(' ')
-}
-
-/** Builds a `pi --model` pattern (`provider/id:<thinking>`) pinning model and thinking level. */
-export function modelPattern(
-  model: { provider: string; id: string },
-  thinkingLevel?: string,
-): string {
-  const base = `${model.provider}/${model.id}`
-  return thinkingLevel !== undefined ? `${base}:${thinkingLevel}` : base
 }

--- a/plugins/usage/src/index.ts
+++ b/plugins/usage/src/index.ts
@@ -18,15 +18,12 @@ import {
 } from './widget'
 
 const EXTENSION_ID = 'usage'
-/** Minimum time between two background usage fetches for the widget. */
 const WIDGET_REFRESH_MS = 30_000
 
 const UsageConfig = Schema.Struct({
-  /** Show rate-limit bars above the editor for the active model's provider. */
   showWidget: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
 })
 
-/** Subscription the widget reports on, derived from the active model. */
 type WidgetProvider = 'claude' | 'codex'
 
 function widgetProvider(
@@ -42,10 +39,6 @@ function widgetProvider(
   }
 }
 
-/**
- * Turns a provider fetch into a report section, mapping failures to an
- * inline message so one provider failing never hides the other.
- */
 function section<A>(
   title: string,
   fetch: Effect.Effect<A, UsageServiceError>,
@@ -59,7 +52,6 @@ function section<A>(
 
 export default function usage(pi: ExtensionAPI): void {
   let config = Schema.decodeUnknownSync(UsageConfig)({})
-  /** Latest widget limits per provider; kept across model switches. */
   const limitsCache = new Map<WidgetProvider, readonly WidgetLimit[]>()
   const fetchedAt = new Map<WidgetProvider, number>()
   const inFlight = new Set<WidgetProvider>()
@@ -72,7 +64,6 @@ export default function usage(pi: ExtensionAPI): void {
     fetchedAt.set(provider, Date.now())
   }
 
-  /** Redraws the segment from cache for the active model's provider. */
   function renderWidget(ctx: ExtensionContext): void {
     if (!ctx.hasUI) {
       return
@@ -89,7 +80,6 @@ export default function usage(pi: ExtensionAPI): void {
     )
   }
 
-  /** Redraws from cache, then refetches in the background when the data is stale. */
   async function refreshWidget(ctx: ExtensionContext): Promise<void> {
     renderWidget(ctx)
     if (!ctx.hasUI || !config.showWidget) {
@@ -113,14 +103,13 @@ export default function usage(pi: ExtensionAPI): void {
         : codexWidgetLimits(yield* service.codex(), new Date())
     }).pipe(Effect.provide(UsageService.layer(ctx.modelRegistry)))
 
-    // On failure keep whatever is shown. /usage reports errors explicitly.
     let limits: WidgetLimit[] | undefined
     try {
       limits = await runHandler(program)
     } finally {
       inFlight.delete(provider)
-      // Record the attempt time even on failure so a broken provider (e.g. not
-      // logged in) is not re-queried on every event.
+      // Stamped on failure too, so a broken provider (e.g. not logged in) is not
+      // re-queried on every event.
       fetchedAt.set(provider, Date.now())
     }
     if (limits !== undefined) {
@@ -181,9 +170,7 @@ export default function usage(pi: ExtensionAPI): void {
           ],
           { concurrency: 'unbounded' },
         )
-        // The UI only shows one message per severity, so group sections by
-        // outcome: all successes in one info message, all failures in one
-        // warning message.
+        // The UI shows one message per severity, so sections are grouped by outcome.
         const rendered = renderSections(sections, now)
         const grouped = { info: [] as string[], warning: [] as string[] }
         sections.forEach((usageSection, index) => {
@@ -208,7 +195,6 @@ export default function usage(pi: ExtensionAPI): void {
       for (const { report, severity } of messages) {
         ctx.ui.notify(report, severity)
       }
-      // The command fetched fresh data for both providers — reuse it.
       renderWidget(ctx)
     },
   })

--- a/plugins/usage/src/provider/anthropic.ts
+++ b/plugins/usage/src/provider/anthropic.ts
@@ -1,26 +1,15 @@
 import { Schema as S } from 'effect'
 import { HttpApi, HttpApiEndpoint, HttpApiGroup } from 'effect/unstable/httpapi'
 
-/**
- * Model of Anthropic's (experimental) subscription usage endpoint:
- *
- *   GET https://api.anthropic.com/api/oauth/usage
- *
- */
-
 export const ANTHROPIC_BASE_URL = 'https://api.anthropic.com'
 export const ANTHROPIC_OAUTH_BETA = 'oauth-2025-04-20'
 
-/** A single rate-limit window. `utilization` is a percentage (0-100). */
 export const UsageWindow = S.Struct({
-  /** Percentage of the window used, 0-100 (may be fractional). */
   utilization: S.optional(S.NullOr(S.Number)),
-  /** ISO 8601 timestamp when the window resets. */
   resets_at: S.optional(S.NullOr(S.String)),
 })
 export type UsageWindow = typeof UsageWindow.Type
 
-/** Pay-as-you-go overage on top of the subscription. Amounts are in minor currency units. */
 export const ExtraUsage = S.Struct({
   is_enabled: S.optional(S.NullOr(S.Boolean)),
   monthly_limit: S.optional(S.NullOr(S.Number)),
@@ -32,13 +21,9 @@ export const ExtraUsage = S.Struct({
 })
 export type ExtraUsage = typeof ExtraUsage.Type
 
-/** Entry of the unified `limits` array (the forward-looking structure). */
 export const UnifiedLimit = S.Struct({
-  /** "session" | "weekly_all" | "weekly_scoped" | future values. */
   kind: S.String,
-  /** Percentage used, 0-100. */
   percent: S.optional(S.NullOr(S.Number)),
-  /** ISO 8601 timestamp (tolerate epoch seconds, as Claude Code does). */
   resets_at: S.optional(S.NullOr(S.Union([S.String, S.Number]))),
   scope: S.optional(
     S.NullOr(
@@ -58,10 +43,6 @@ export const UnifiedLimit = S.Struct({
 })
 export type UnifiedLimit = typeof UnifiedLimit.Type
 
-/**
- * Usage response. Windows the plan doesn't have are `null` (not omitted), and
- * new (codename) windows appear over time, so unknown keys must be tolerated.
- */
 export const ClaudeUsage = S.Struct({
   five_hour: S.optional(S.NullOr(UsageWindow)),
   seven_day: S.optional(S.NullOr(UsageWindow)),

--- a/plugins/usage/src/provider/openai.ts
+++ b/plugins/usage/src/provider/openai.ts
@@ -1,24 +1,12 @@
 import { Schema as S } from 'effect'
 import { HttpApi, HttpApiEndpoint, HttpApiGroup } from 'effect/unstable/httpapi'
 
-/**
- * Model of the ChatGPT backend usage endpoint the Codex CLI uses:
- *
- *   GET https://chatgpt.com/backend-api/wham/usage
- *
- */
-
 export const CHATGPT_BASE_URL = 'https://chatgpt.com'
 
-/** Snapshot of one rate-limit window. */
 export const RateLimitWindow = S.Struct({
-  /** Integer percentage used, 0-100. */
   used_percent: S.Number,
-  /** Window duration in seconds (e.g. 18000 = 5h, 604800 = 1 week). */
   limit_window_seconds: S.optional(S.NullOr(S.Number)),
-  /** Seconds until the window resets. */
   reset_after_seconds: S.optional(S.NullOr(S.Number)),
-  /** Unix timestamp (seconds) when the window resets. */
   reset_at: S.optional(S.NullOr(S.Number)),
 })
 export type RateLimitWindow = typeof RateLimitWindow.Type
@@ -26,9 +14,7 @@ export type RateLimitWindow = typeof RateLimitWindow.Type
 export const RateLimitDetails = S.Struct({
   allowed: S.optional(S.NullOr(S.Boolean)),
   limit_reached: S.optional(S.NullOr(S.Boolean)),
-  /** Short window (currently 5h). */
   primary_window: S.optional(S.NullOr(RateLimitWindow)),
-  /** Long window (currently weekly). */
   secondary_window: S.optional(S.NullOr(RateLimitWindow)),
 })
 export type RateLimitDetails = typeof RateLimitDetails.Type
@@ -36,7 +22,6 @@ export type RateLimitDetails = typeof RateLimitDetails.Type
 export const CreditStatus = S.Struct({
   has_credits: S.optional(S.NullOr(S.Boolean)),
   unlimited: S.optional(S.NullOr(S.Boolean)),
-  /** Decimal string, e.g. "9.99". */
   balance: S.optional(S.NullOr(S.String)),
 })
 export type CreditStatus = typeof CreditStatus.Type
@@ -48,12 +33,10 @@ export const AdditionalRateLimit = S.Struct({
 export type AdditionalRateLimit = typeof AdditionalRateLimit.Type
 
 export const CodexUsage = S.Struct({
-  /** Plan slug, e.g. "plus" | "pro" | "team" | "business" | "enterprise" | ... */
   plan_type: S.optional(S.NullOr(S.String)),
   rate_limit: S.optional(S.NullOr(RateLimitDetails)),
   credits: S.optional(S.NullOr(CreditStatus)),
   additional_rate_limits: S.optional(S.NullOr(S.Array(AdditionalRateLimit))),
-  /** Credits that lift a reached rate limit early (e.g. "3 available"). */
   rate_limit_reset_credits: S.optional(
     S.NullOr(S.Struct({ available_count: S.Number })),
   ),

--- a/plugins/usage/src/render.ts
+++ b/plugins/usage/src/render.ts
@@ -1,4 +1,4 @@
-import type { ClaudeUsage, UsageWindow } from './provider/anthropic'
+import type { ClaudeUsage, UnifiedLimit, UsageWindow } from './provider/anthropic'
 import type { CodexUsage, RateLimitDetails } from './provider/openai'
 import { codexResetsAt, formatDuration, parseResetsAt } from './reset'
 
@@ -15,6 +15,30 @@ export interface UsageRow {
 export type UsageSection =
   | { readonly title: string; readonly rows: readonly UsageRow[] }
   | { readonly title: string; readonly error: string }
+
+function formatRow(row: UsageRow, now: Date, labelWidth: number): string {
+  const parts = [`  ${row.label.padEnd(labelWidth)}`]
+
+  if (typeof row.percent === 'number') {
+    const clamped = Math.min(Math.max(row.percent, 0), 100)
+    const filled = Math.round((clamped / 100) * BAR_WIDTH)
+    parts.push(
+      `[${'█'.repeat(filled)}${'░'.repeat(BAR_WIDTH - filled)}]`,
+      `${Math.round(row.percent)}%`.padStart(4),
+    )
+  }
+
+  if (row.resetsAt) {
+    const delta = row.resetsAt.getTime() - now.getTime()
+    parts.push(delta > 0 ? `· resets in ${formatDuration(delta)}` : '· resets soon')
+  }
+
+  if (row.note) {
+    parts.push(parts.length > 1 ? `· ${row.note}` : row.note)
+  }
+
+  return parts.join(' ')
+}
 
 export function renderSections(
   sections: readonly UsageSection[],
@@ -33,32 +57,10 @@ export function renderSections(
     if (section.rows.length === 0) {
       return `${section.title}\n  (no usage data reported)`
     }
-    const lines = section.rows.map((row) => {
-      const parts = [`  ${row.label.padEnd(labelWidth)}`]
-
-      if (typeof row.percent === 'number') {
-        const clamped = Math.min(Math.max(row.percent, 0), 100)
-        const filled = Math.round((clamped / 100) * BAR_WIDTH)
-        parts.push(
-          `[${'█'.repeat(filled)}${'░'.repeat(BAR_WIDTH - filled)}]`,
-          `${Math.round(row.percent)}%`.padStart(4),
-        )
-      }
-
-      if (row.resetsAt) {
-        const delta = row.resetsAt.getTime() - now.getTime()
-        parts.push(
-          delta > 0 ? `· resets in ${formatDuration(delta)}` : '· resets soon',
-        )
-      }
-
-      if (row.note) {
-        parts.push(parts.length > 1 ? `· ${row.note}` : row.note)
-      }
-
-      return parts.join(' ')
-    })
-    return [section.title, ...lines].join('\n')
+    return [
+      section.title,
+      ...section.rows.map((row) => formatRow(row, now, labelWidth)),
+    ].join('\n')
   })
 }
 
@@ -80,6 +82,21 @@ function formatMinorAmount(
   return value.toFixed(decimalPlaces)
 }
 
+function unifiedLimitLabel(limit: UnifiedLimit): string {
+  switch (limit.kind) {
+    case 'session':
+      return 'Session (5h)'
+    case 'weekly_all':
+      return 'Week (all models)'
+    case 'weekly_scoped': {
+      const model = limit.scope?.model
+      return `Week (${model?.display_name ?? model?.id ?? 'scoped'})`
+    }
+    default:
+      return limit.kind
+  }
+}
+
 export function claudeSection(usage: ClaudeUsage): UsageSection {
   const rows: UsageRow[] = []
 
@@ -88,24 +105,8 @@ export function claudeSection(usage: ClaudeUsage): UsageSection {
     // `is_active` marks the currently binding limit, not visibility, so every
     // limit is listed.
     for (const limit of limits) {
-      let label: string
-      switch (limit.kind) {
-        case 'session':
-          label = 'Session (5h)'
-          break
-        case 'weekly_all':
-          label = 'Week (all models)'
-          break
-        case 'weekly_scoped': {
-          const model = limit.scope?.model
-          label = `Week (${model?.display_name ?? model?.id ?? 'scoped'})`
-          break
-        }
-        default:
-          label = limit.kind
-      }
       rows.push({
-        label,
+        label: unifiedLimitLabel(limit),
         percent: limit.percent,
         resetsAt: parseResetsAt(limit.resets_at),
       })
@@ -162,6 +163,19 @@ export function claudeSection(usage: ClaudeUsage): UsageSection {
   return { title: 'Claude', rows }
 }
 
+function codexWindowName(seconds: number | null | undefined): string {
+  if (typeof seconds !== 'number' || seconds <= 0) {
+    return 'Window'
+  }
+  if (seconds >= 604_800 * 0.9) {
+    return 'Week'
+  }
+  if (seconds >= 86_400) {
+    return `${Math.round(seconds / 86_400)}d`
+  }
+  return `${Math.round(seconds / 3600)}h`
+}
+
 function codexWindowRows(
   details: RateLimitDetails | null | undefined,
   now: Date,
@@ -172,17 +186,8 @@ function codexWindowRows(
     if (!window) {
       continue
     }
-    const seconds = window.limit_window_seconds
-    const name =
-      typeof seconds !== 'number' || seconds <= 0
-        ? 'Window'
-        : seconds >= 604_800 * 0.9
-          ? 'Week'
-          : seconds >= 86_400
-            ? `${Math.round(seconds / 86_400)}d`
-            : `${Math.round(seconds / 3600)}h`
     rows.push({
-      label: labelFor(name),
+      label: labelFor(codexWindowName(window.limit_window_seconds)),
       percent: window.used_percent,
       resetsAt: codexResetsAt(window, now),
     })

--- a/plugins/usage/src/render.ts
+++ b/plugins/usage/src/render.ts
@@ -1,4 +1,4 @@
-import type { ClaudeUsage, UnifiedLimit, UsageWindow } from './provider/anthropic'
+import type { ClaudeUsage, UsageWindow } from './provider/anthropic'
 import type { CodexUsage, RateLimitDetails } from './provider/openai'
 import { codexResetsAt, formatDuration, parseResetsAt } from './reset'
 
@@ -7,66 +7,15 @@ const BAR_WIDTH = 10
 
 export interface UsageRow {
   readonly label: string
-  /** Percentage used, 0-100. */
   readonly percent?: number | null | undefined
   readonly resetsAt?: Date | null | undefined
-  /** Free-form suffix (used instead of / in addition to the bar). */
   readonly note?: string | undefined
 }
 
-/** One provider block of the report: usage rows, or an inline failure. */
 export type UsageSection =
   | { readonly title: string; readonly rows: readonly UsageRow[] }
   | { readonly title: string; readonly error: string }
 
-function bar(percent: number): string {
-  const clamped = Math.min(Math.max(percent, 0), 100)
-  const filled = Math.round((clamped / 100) * BAR_WIDTH)
-  return `[${'█'.repeat(filled)}${'░'.repeat(BAR_WIDTH - filled)}]`
-}
-
-function formatRow(row: UsageRow, now: Date, labelWidth: number): string {
-  const parts = [`  ${row.label.padEnd(labelWidth)}`]
-
-  if (typeof row.percent === 'number') {
-    parts.push(bar(row.percent), `${Math.round(row.percent)}%`.padStart(4))
-  }
-
-  if (row.resetsAt) {
-    const delta = row.resetsAt.getTime() - now.getTime()
-    parts.push(delta > 0 ? `· resets in ${formatDuration(delta)}` : '· resets soon')
-  }
-
-  if (row.note) {
-    // Separate the note from a preceding bar/percent or reset, but keep
-    // note-only rows (e.g. "disabled — …") unprefixed.
-    parts.push(parts.length > 1 ? `· ${row.note}` : row.note)
-  }
-
-  return parts.join(' ')
-}
-
-function renderSection(
-  section: UsageSection,
-  now: Date,
-  labelWidth: number,
-): string[] {
-  if ('error' in section) {
-    return [section.title, `  ${section.error}`]
-  }
-  if (section.rows.length === 0) {
-    return [section.title, '  (no usage data reported)']
-  }
-  return [
-    section.title,
-    ...section.rows.map((row) => formatRow(row, now, labelWidth)),
-  ]
-}
-
-/**
- * Renders each section to its own string, using a shared label width so bars
- * and percentages line up across providers, not just within one section.
- */
 export function renderSections(
   sections: readonly UsageSection[],
   now: Date,
@@ -77,49 +26,40 @@ export function renderSections(
       'rows' in section ? section.rows.map((row) => row.label.length) : [],
     ),
   )
-  return sections.map((section) =>
-    renderSection(section, now, labelWidth).join('\n'),
-  )
-}
-
-// ─── Claude ──────────────────────────────────────────────────────────────────
-
-function windowRow(
-  label: string,
-  window: UsageWindow | null | undefined,
-): UsageRow | null {
-  if (!window || typeof window.utilization !== 'number') {
-    return null
-  }
-  return {
-    label,
-    percent: window.utilization,
-    resetsAt: parseResetsAt(window.resets_at),
-  }
-}
-
-function unifiedLimitLabel(limit: UnifiedLimit): string {
-  switch (limit.kind) {
-    case 'session':
-      return 'Session (5h)'
-    case 'weekly_all':
-      return 'Week (all models)'
-    case 'weekly_scoped': {
-      const model = limit.scope?.model
-      return `Week (${model?.display_name ?? model?.id ?? 'scoped'})`
+  return sections.map((section) => {
+    if ('error' in section) {
+      return `${section.title}\n  ${section.error}`
     }
-    default:
-      return limit.kind
-  }
-}
+    if (section.rows.length === 0) {
+      return `${section.title}\n  (no usage data reported)`
+    }
+    const lines = section.rows.map((row) => {
+      const parts = [`  ${row.label.padEnd(labelWidth)}`]
 
-/** "out_of_credit" -> "Out Of Credit" */
-function formatIdentifier(value: string): string {
-  return value
-    .split('_')
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(' ')
+      if (typeof row.percent === 'number') {
+        const clamped = Math.min(Math.max(row.percent, 0), 100)
+        const filled = Math.round((clamped / 100) * BAR_WIDTH)
+        parts.push(
+          `[${'█'.repeat(filled)}${'░'.repeat(BAR_WIDTH - filled)}]`,
+          `${Math.round(row.percent)}%`.padStart(4),
+        )
+      }
+
+      if (row.resetsAt) {
+        const delta = row.resetsAt.getTime() - now.getTime()
+        parts.push(
+          delta > 0 ? `· resets in ${formatDuration(delta)}` : '· resets soon',
+        )
+      }
+
+      if (row.note) {
+        parts.push(parts.length > 1 ? `· ${row.note}` : row.note)
+      }
+
+      return parts.join(' ')
+    })
+    return [section.title, ...lines].join('\n')
+  })
 }
 
 function formatMinorAmount(
@@ -134,7 +74,7 @@ function formatMinorAmount(
         value,
       )
     } catch {
-      // Unknown currency code — fall through to the plain rendering.
+      // Unknown currency code.
     }
   }
   return value.toFixed(decimalPlaces)
@@ -145,11 +85,27 @@ export function claudeSection(usage: ClaudeUsage): UsageSection {
 
   const limits = usage.limits ?? []
   if (limits.length > 0) {
-    // The unified `limits` array supersedes the flat windows when present.
-    // Note: `is_active` marks the currently binding limit, not visibility.
+    // `is_active` marks the currently binding limit, not visibility, so every
+    // limit is listed.
     for (const limit of limits) {
+      let label: string
+      switch (limit.kind) {
+        case 'session':
+          label = 'Session (5h)'
+          break
+        case 'weekly_all':
+          label = 'Week (all models)'
+          break
+        case 'weekly_scoped': {
+          const model = limit.scope?.model
+          label = `Week (${model?.display_name ?? model?.id ?? 'scoped'})`
+          break
+        }
+        default:
+          label = limit.kind
+      }
       rows.push({
-        label: unifiedLimitLabel(limit),
+        label,
         percent: limit.percent,
         resetsAt: parseResetsAt(limit.resets_at),
       })
@@ -162,9 +118,12 @@ export function claudeSection(usage: ClaudeUsage): UsageSection {
       ['Week (Sonnet)', usage.seven_day_sonnet],
     ]
     for (const [label, window] of flatWindows) {
-      const row = windowRow(label, window)
-      if (row) {
-        rows.push(row)
+      if (window && typeof window.utilization === 'number') {
+        rows.push({
+          label,
+          percent: window.utilization,
+          resetsAt: parseResetsAt(window.resets_at),
+        })
       }
     }
   }
@@ -188,31 +147,19 @@ export function claudeSection(usage: ClaudeUsage): UsageSection {
       })
     }
     if (extra.is_enabled === false) {
+      const reason = extra.disabled_reason
+        ?.split('_')
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ')
       rows.push({
         label: 'Extra usage',
-        note: extra.disabled_reason
-          ? `disabled — ${formatIdentifier(extra.disabled_reason)}`
-          : 'disabled',
+        note: reason ? `disabled — ${reason}` : 'disabled',
       })
     }
   }
 
   return { title: 'Claude', rows }
-}
-
-// ─── OpenAI Codex ────────────────────────────────────────────────────────────
-
-function codexWindowName(seconds: number | null | undefined): string {
-  if (typeof seconds !== 'number' || seconds <= 0) {
-    return 'Window'
-  }
-  if (seconds >= 604_800 * 0.9) {
-    return 'Week'
-  }
-  if (seconds >= 86_400) {
-    return `${Math.round(seconds / 86_400)}d`
-  }
-  return `${Math.round(seconds / 3600)}h`
 }
 
 function codexWindowRows(
@@ -225,8 +172,17 @@ function codexWindowRows(
     if (!window) {
       continue
     }
+    const seconds = window.limit_window_seconds
+    const name =
+      typeof seconds !== 'number' || seconds <= 0
+        ? 'Window'
+        : seconds >= 604_800 * 0.9
+          ? 'Week'
+          : seconds >= 86_400
+            ? `${Math.round(seconds / 86_400)}d`
+            : `${Math.round(seconds / 3600)}h`
     rows.push({
-      label: labelFor(codexWindowName(window.limit_window_seconds)),
+      label: labelFor(name),
       percent: window.used_percent,
       resetsAt: codexResetsAt(window, now),
     })

--- a/plugins/usage/src/reset.ts
+++ b/plugins/usage/src/reset.ts
@@ -1,10 +1,10 @@
 import type { RateLimitWindow } from './provider/openai'
 
-/** Claude sends ISO 8601 strings, but epoch seconds occur too (as Claude Code assumes). */
 export function parseResetsAt(
   value: string | number | null | undefined,
 ): Date | null {
   if (typeof value === 'number') {
+    // Epoch seconds, as Claude Code assumes.
     return new Date(value * 1000)
   }
   if (typeof value === 'string') {
@@ -14,7 +14,6 @@ export function parseResetsAt(
   return null
 }
 
-/** Codex reports a relative offset, and only sometimes an absolute timestamp. */
 export function codexResetsAt(window: RateLimitWindow, now: Date): Date | null {
   if (typeof window.reset_after_seconds === 'number') {
     return new Date(now.getTime() + window.reset_after_seconds * 1000)
@@ -25,7 +24,6 @@ export function codexResetsAt(window: RateLimitWindow, now: Date): Date | null {
   return null
 }
 
-/** "42m", "2h 13m", "4d 2h" */
 export function formatDuration(ms: number): string {
   const minutes = Math.max(Math.ceil(ms / 60_000), 0)
   if (minutes < 60) {
@@ -39,10 +37,6 @@ export function formatDuration(ms: number): string {
   return `${days}d ${hours % 24}h`
 }
 
-/**
- * "42m", "2h", "4d" — a single, rounded-down unit for the status line, where
- * the exact remainder is not worth the columns.
- */
 export function formatCompactDuration(ms: number): string {
   const minutes = Math.floor(ms / 60_000)
   if (minutes < 60) {

--- a/plugins/usage/src/service.ts
+++ b/plugins/usage/src/service.ts
@@ -72,6 +72,29 @@ type CredentialsFor<P extends UsageProvider> = Data.TaggedEnum.Value<
   P['_tag']
 >
 
+const accountIdFromToken = Effect.fnUntraced(function* (accessToken: string) {
+  const payload = yield* Effect.fromResult(
+    Encoding.decodeBase64UrlString(
+      pipe(
+        accessToken,
+        String.split('.'),
+        Array.get(1),
+        Option.getOrElse(() => ''),
+      ),
+    ),
+  )
+  const claims = yield* Schema.decodeEffect(
+    Schema.fromJsonString(
+      Schema.Struct({
+        'https://api.openai.com/auth': Schema.Struct({
+          chatgpt_account_id: Schema.String,
+        }),
+      }),
+    ),
+  )(payload)
+  return claims['https://api.openai.com/auth'].chatgpt_account_id
+})
+
 export class UsageService extends Context.Service<UsageService>()(
   '@pi-plugins/usage/UsageService',
   {
@@ -128,28 +151,9 @@ export class UsageService extends Context.Service<UsageService>()(
                 : undefined
             const accountId =
               storedAccountId ??
-              (yield* Effect.gen(function* () {
-                const payload = yield* Effect.fromResult(
-                  Encoding.decodeBase64UrlString(
-                    pipe(
-                      accessToken,
-                      String.split('.'),
-                      Array.get(1),
-                      Option.getOrElse(() => ''),
-                    ),
-                  ),
-                )
-                const claims = yield* Schema.decodeEffect(
-                  Schema.fromJsonString(
-                    Schema.Struct({
-                      'https://api.openai.com/auth': Schema.Struct({
-                        chatgpt_account_id: Schema.String,
-                      }),
-                    }),
-                  ),
-                )(payload)
-                return claims['https://api.openai.com/auth'].chatgpt_account_id
-              }).pipe(Effect.orElseSucceed(() => undefined)))
+              (yield* accountIdFromToken(accessToken).pipe(
+                Effect.orElseSucceed(() => undefined),
+              ))
             if (!accountId) {
               return yield* new UsageServiceError({
                 kind: 'AccountIdMissing',

--- a/plugins/usage/src/service.ts
+++ b/plugins/usage/src/service.ts
@@ -55,53 +55,22 @@ const requestFailed = (cause: unknown) =>
     cause,
   })
 
-/** Subscription providers the service knows how to query. */
 export type UsageProvider = Data.TaggedEnum<{
   Anthropic: {}
   OpenAI: {}
 }>
 export const UsageProvider = Data.taggedEnum<UsageProvider>()
 
-/** OAuth credentials resolved from pi's auth store. */
 export type UsageCredentials = Data.TaggedEnum<{
   Anthropic: { readonly accessToken: string }
-  OpenAI: {
-    readonly accessToken: string
-    /** ChatGPT account/workspace id (JWT `chatgpt_account_id` claim). */
-    readonly accountId: string
-  }
+  OpenAI: { readonly accessToken: string; readonly accountId: string }
 }>
 export const UsageCredentials = Data.taggedEnum<UsageCredentials>()
 
-/** The credentials variant belonging to a provider variant. */
 type CredentialsFor<P extends UsageProvider> = Data.TaggedEnum.Value<
   UsageCredentials,
   P['_tag']
 >
-
-/** Extracts the ChatGPT account/workspace id from the access token JWT. */
-const accountIdFromToken = Effect.fnUntraced(function* (accessToken: string) {
-  const payload = yield* Effect.fromResult(
-    Encoding.decodeBase64UrlString(
-      pipe(
-        accessToken,
-        String.split('.'),
-        Array.get(1),
-        Option.getOrElse(() => ''),
-      ),
-    ),
-  )
-  const claims = yield* Schema.decodeEffect(
-    Schema.fromJsonString(
-      Schema.Struct({
-        'https://api.openai.com/auth': Schema.Struct({
-          chatgpt_account_id: Schema.String,
-        }),
-      }),
-    ),
-  )(payload)
-  return claims['https://api.openai.com/auth'].chatgpt_account_id
-})
 
 export class UsageService extends Context.Service<UsageService>()(
   '@pi-plugins/usage/UsageService',
@@ -116,11 +85,9 @@ export class UsageService extends Context.Service<UsageService>()(
         }),
       )
 
-      /** Resolves subscription OAuth credentials for `provider` from pi's auth store. */
       const credentials = Effect.fnUntraced(function* <P extends UsageProvider>(
         provider: P,
       ): Effect.fn.Return<CredentialsFor<P>, UsageServiceError> {
-        // Provider ids as stored in pi's auth store (`~/.pi/agent/auth.json`).
         const providerId = UsageProvider.$match(provider, {
           Anthropic: () => 'anthropic',
           OpenAI: () => 'openai-codex',
@@ -152,7 +119,7 @@ export class UsageService extends Context.Service<UsageService>()(
           Anthropic: () =>
             Effect.succeed(UsageCredentials.Anthropic({ accessToken })),
           OpenAI: Effect.fnUntraced(function* () {
-            // Re-read after auth resolution, which may have refreshed the stored credential.
+            // Re-read: resolving the token may have refreshed the stored credential.
             const credential = readStoredCredential(providerId)
             const storedAccountId =
               credential?.type === 'oauth' &&
@@ -161,9 +128,28 @@ export class UsageService extends Context.Service<UsageService>()(
                 : undefined
             const accountId =
               storedAccountId ??
-              (yield* accountIdFromToken(accessToken).pipe(
-                Effect.orElseSucceed(() => undefined),
-              ))
+              (yield* Effect.gen(function* () {
+                const payload = yield* Effect.fromResult(
+                  Encoding.decodeBase64UrlString(
+                    pipe(
+                      accessToken,
+                      String.split('.'),
+                      Array.get(1),
+                      Option.getOrElse(() => ''),
+                    ),
+                  ),
+                )
+                const claims = yield* Schema.decodeEffect(
+                  Schema.fromJsonString(
+                    Schema.Struct({
+                      'https://api.openai.com/auth': Schema.Struct({
+                        chatgpt_account_id: Schema.String,
+                      }),
+                    }),
+                  ),
+                )(payload)
+                return claims['https://api.openai.com/auth'].chatgpt_account_id
+              }).pipe(Effect.orElseSucceed(() => undefined)))
             if (!accountId) {
               return yield* new UsageServiceError({
                 kind: 'AccountIdMissing',

--- a/plugins/usage/src/widget.ts
+++ b/plugins/usage/src/widget.ts
@@ -2,33 +2,14 @@ import type { ClaudeUsage, UsageWindow } from './provider/anthropic'
 import type { CodexUsage } from './provider/openai'
 import { codexResetsAt, formatCompactDuration, parseResetsAt } from './reset'
 
-/** One compact rate-limit entry shown on the shared status line. */
 export interface WidgetLimit {
-  /** Short window label, e.g. "5h" or "wk". */
   readonly label: string
-  /** Percentage used, 0-100. */
   readonly percent: number
-  /** When the window rolls over, if the provider reported it. */
   readonly resetsAt?: Date | null | undefined
 }
 
 const BAR_WIDTH = 5
 
-function bar(percent: number): string {
-  const clamped = Math.min(Math.max(percent, 0), 100)
-  const filled = Math.round((clamped / 100) * BAR_WIDTH)
-  return `${'█'.repeat(filled)}${'░'.repeat(BAR_WIDTH - filled)}`
-}
-
-function reset(limit: WidgetLimit, now: Date): string {
-  if (!limit.resetsAt) {
-    return ''
-  }
-  const delta = limit.resetsAt.getTime() - now.getTime()
-  return ` (${delta > 0 ? formatCompactDuration(delta) : 'now'})`
-}
-
-/** "5h ██░░░ 41% (2h) · wk ███░░ 62% (4d)", or `undefined` when there is nothing to show. */
 export function widgetText(
   limits: readonly WidgetLimit[] | undefined,
   now: Date,
@@ -37,34 +18,30 @@ export function widgetText(
     return undefined
   }
   return limits
-    .map(
-      (limit) =>
-        `${limit.label} ${bar(limit.percent)} ${Math.round(limit.percent)}%` +
-        reset(limit, now),
-    )
+    .map((limit) => {
+      const clamped = Math.min(Math.max(limit.percent, 0), 100)
+      const filled = Math.round((clamped / 100) * BAR_WIDTH)
+      const bar = `${'█'.repeat(filled)}${'░'.repeat(BAR_WIDTH - filled)}`
+      const text = `${limit.label} ${bar} ${Math.round(limit.percent)}%`
+      if (!limit.resetsAt) {
+        return text
+      }
+      const delta = limit.resetsAt.getTime() - now.getTime()
+      return `${text} (${delta > 0 ? formatCompactDuration(delta) : 'now'})`
+    })
     .join(' · ')
-}
-
-// ─── Claude ──────────────────────────────────────────────────────────────────
-
-/** Short label for a unified-limit kind; model-scoped weekly limits are skipped. */
-function claudeLimitLabel(kind: string): string | undefined {
-  switch (kind) {
-    case 'session':
-      return '5h'
-    case 'weekly_all':
-      return 'wk'
-    default:
-      return undefined
-  }
 }
 
 export function claudeWidgetLimits(usage: ClaudeUsage): WidgetLimit[] {
   const limits = usage.limits ?? []
   if (limits.length > 0) {
-    // The unified `limits` array supersedes the flat windows when present.
     return limits.flatMap((limit) => {
-      const label = claudeLimitLabel(limit.kind)
+      const label =
+        limit.kind === 'session'
+          ? '5h'
+          : limit.kind === 'weekly_all'
+            ? 'wk'
+            : undefined
       return label !== undefined && typeof limit.percent === 'number'
         ? [
             {
@@ -94,32 +71,27 @@ export function claudeWidgetLimits(usage: ClaudeUsage): WidgetLimit[] {
   )
 }
 
-// ─── OpenAI Codex ────────────────────────────────────────────────────────────
-
-function codexWindowLabel(seconds: number | null | undefined): string {
-  if (typeof seconds !== 'number' || seconds <= 0) {
-    return '?'
-  }
-  if (seconds >= 604_800 * 0.9) {
-    return 'wk'
-  }
-  if (seconds >= 86_400) {
-    return `${Math.round(seconds / 86_400)}d`
-  }
-  return `${Math.round(seconds / 3600)}h`
-}
-
 export function codexWidgetLimits(usage: CodexUsage, now: Date): WidgetLimit[] {
   const details = usage.rate_limit
-  return [details?.primary_window, details?.secondary_window].flatMap((window) =>
-    window
-      ? [
-          {
-            label: codexWindowLabel(window.limit_window_seconds),
-            percent: window.used_percent,
-            resetsAt: codexResetsAt(window, now),
-          },
-        ]
-      : [],
-  )
+  return [details?.primary_window, details?.secondary_window].flatMap((window) => {
+    if (!window) {
+      return []
+    }
+    const seconds = window.limit_window_seconds
+    const label =
+      typeof seconds !== 'number' || seconds <= 0
+        ? '?'
+        : seconds >= 604_800 * 0.9
+          ? 'wk'
+          : seconds >= 86_400
+            ? `${Math.round(seconds / 86_400)}d`
+            : `${Math.round(seconds / 3600)}h`
+    return [
+      {
+        label,
+        percent: window.used_percent,
+        resetsAt: codexResetsAt(window, now),
+      },
+    ]
+  })
 }

--- a/plugins/usage/src/widget.ts
+++ b/plugins/usage/src/widget.ts
@@ -71,27 +71,30 @@ export function claudeWidgetLimits(usage: ClaudeUsage): WidgetLimit[] {
   )
 }
 
+function codexWindowLabel(seconds: number | null | undefined): string {
+  if (typeof seconds !== 'number' || seconds <= 0) {
+    return '?'
+  }
+  if (seconds >= 604_800 * 0.9) {
+    return 'wk'
+  }
+  if (seconds >= 86_400) {
+    return `${Math.round(seconds / 86_400)}d`
+  }
+  return `${Math.round(seconds / 3600)}h`
+}
+
 export function codexWidgetLimits(usage: CodexUsage, now: Date): WidgetLimit[] {
   const details = usage.rate_limit
-  return [details?.primary_window, details?.secondary_window].flatMap((window) => {
-    if (!window) {
-      return []
-    }
-    const seconds = window.limit_window_seconds
-    const label =
-      typeof seconds !== 'number' || seconds <= 0
-        ? '?'
-        : seconds >= 604_800 * 0.9
-          ? 'wk'
-          : seconds >= 86_400
-            ? `${Math.round(seconds / 86_400)}d`
-            : `${Math.round(seconds / 3600)}h`
-    return [
-      {
-        label,
-        percent: window.used_percent,
-        resetsAt: codexResetsAt(window, now),
-      },
-    ]
-  })
+  return [details?.primary_window, details?.secondary_window].flatMap((window) =>
+    window
+      ? [
+          {
+            label: codexWindowLabel(window.limit_window_seconds),
+            percent: window.used_percent,
+            resetsAt: codexResetsAt(window, now),
+          },
+        ]
+      : [],
+  )
 }

--- a/plugins/webfetch/src/converter.ts
+++ b/plugins/webfetch/src/converter.ts
@@ -27,8 +27,7 @@ export class HtmlConverter extends Context.Service<
         const response = yield* Effect.tryPromise({
           try: () => {
             const { document } = parseHTML(html)
-            // defuddle reads the page URL from `location`, which linkedom leaves
-            // unset, and never falls back to the url argument below.
+            // defuddle reads the page URL from `location`, which linkedom leaves unset.
             Object.assign(document, { location: { href: url } })
             return Defuddle(document, url, { markdown: true })
           },

--- a/plugins/webfetch/src/fetch.ts
+++ b/plugins/webfetch/src/fetch.ts
@@ -28,18 +28,6 @@ const BROWSER_HEADERS = {
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
 }
 
-function shouldConvertToMarkdown(
-  contentType: string | undefined,
-  content: string,
-): boolean {
-  if (contentType !== undefined) {
-    const mediaType = contentType.split(';', 1)[0]?.trim().toLowerCase()
-    return mediaType === 'text/html' || mediaType === 'application/xhtml+xml'
-  }
-  const prefix = content.trimStart().slice(0, 1024)
-  return /^(?:<!doctype html|<html|<\?xml[\s\S]*<html)/i.test(prefix)
-}
-
 interface WebFetchService {
   fetch: (options: {
     url: string
@@ -78,17 +66,20 @@ export class WebFetch extends Context.Service<WebFetch, WebFetchService>()(
               Accept: ACCEPT_HEADERS[options.format],
             },
           })
-          const contentType = response.headers['content-type']
           const raw = yield* response.text
-
-          if (
-            options.format === 'markdown' &&
-            shouldConvertToMarkdown(contentType, raw)
-          ) {
-            return yield* converter.toMarkdown(raw, options.url)
+          if (options.format !== 'markdown') {
+            return raw
           }
 
-          return raw
+          const contentType = response.headers['content-type']
+          const mediaType = contentType?.split(';', 1)[0]?.trim().toLowerCase()
+          const isHtml =
+            contentType === undefined
+              ? /^(?:<!doctype html|<html|<\?xml[\s\S]*<html)/i.test(
+                  raw.trimStart().slice(0, 1024),
+                )
+              : mediaType === 'text/html' || mediaType === 'application/xhtml+xml'
+          return isHtml ? yield* converter.toMarkdown(raw, options.url) : raw
         },
         (_, options) =>
           _.pipe(

--- a/plugins/webfetch/src/index.ts
+++ b/plugins/webfetch/src/index.ts
@@ -8,7 +8,6 @@ import { WebFetch, type WebFetchFormat } from './fetch'
 
 const DEFAULT_TIMEOUT_SECONDS = 30
 const MAX_TIMEOUT_SECONDS = 120
-/** Wrapped terminal rows, not source lines: fetched pages are prose, not code. */
 const PREVIEW_LINES = 5
 
 const webFetchSchema = Type.Object({

--- a/tooling/shared/src/config.ts
+++ b/tooling/shared/src/config.ts
@@ -4,11 +4,6 @@ import * as NodeServices from '@effect/platform-node/NodeServices'
 import { Effect, FileSystem, Path, PlatformError, Schema } from 'effect'
 import { runHandler } from './run'
 
-/**
- * A missing config file yields `defaults` silently. An unreadable or invalid
- * one warns and yields `defaults`, so a typo downgrades the extension rather
- * than breaking it.
- */
 export const loadExtensionConfig = Effect.fnUntraced(
   function* <S extends Schema.Codec<unknown>>(
     _ctx: ExtensionContext,

--- a/tooling/shared/src/run.ts
+++ b/tooling/shared/src/run.ts
@@ -1,18 +1,13 @@
 import { Cause, Effect, Exit, Inspectable } from 'effect'
 
-// What pi's own tools throw for a cancelled run, so interrupted plugin runs
-// read like interrupted builtins.
-const ABORT_MESSAGE = 'Operation aborted'
-
 export interface RunOptions {
   readonly signal?: AbortSignal | undefined
 }
 
-// Defects keep their stack because they are bugs, and win over failures in a
-// mixed cause.
 function causeMessage(cause: Cause.Cause<unknown>): string {
   if (Cause.hasInterruptsOnly(cause)) {
-    return ABORT_MESSAGE
+    // What pi's own tools throw for a cancelled run.
+    return 'Operation aborted'
   }
   if (Cause.hasDies(cause)) {
     return Cause.pretty(cause)
@@ -28,10 +23,7 @@ function causeMessage(cause: Cause.Cause<unknown>): string {
     .join('\n')
 }
 
-/**
- * Failure rejects with an `Error` whose message is what the model reads back
- * as the tool result, so it is written for the model rather than for a log.
- */
+/** The rejection message is what the model reads back as the tool result. */
 export async function runTool<A, E>(
   effect: Effect.Effect<A, E>,
   options?: RunOptions,
@@ -47,12 +39,6 @@ export interface RunHandlerOptions<B> {
   readonly onError?: (message: string) => B
 }
 
-/**
- * For boundaries where pi reports rejections but expected failures should
- * degrade gracefully (event hooks, commands, background work). Expected
- * failures and interrupts never reject. Without `onError` they vanish, while
- * defects rethrow so pi's handler boundary reports the bug.
- */
 export async function runHandler<A, E, B = undefined>(
   effect: Effect.Effect<A, E>,
   options?: RunHandlerOptions<B>,

--- a/tooling/shared/src/statusline.ts
+++ b/tooling/shared/src/statusline.ts
@@ -30,6 +30,10 @@ function side(segments: Registry, align: StatuslineSegment['align']): string {
   )
 }
 
+function textWidth(text: string): number {
+  return Array.fromIterable(text).length
+}
+
 export function setStatuslineSegment(
   ctx: ExtensionContext,
   key: string,
@@ -62,8 +66,7 @@ export function setStatuslineSegment(
       // Left indented one column like pi's widget rows, right flush like pi's footer.
       const margin = Math.min(width, 1)
       const inner = width - margin
-      const gap =
-        inner - Array.fromIterable(left).length - Array.fromIterable(right).length
+      const gap = inner - textWidth(left) - textWidth(right)
       const minGap = String.isNonEmpty(left) && String.isNonEmpty(right) ? 2 : 0
 
       const line =

--- a/tooling/shared/src/statusline.ts
+++ b/tooling/shared/src/statusline.ts
@@ -1,12 +1,8 @@
-import type { ExtensionContext, Theme } from '@earendil-works/pi-coding-agent'
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent'
 import { Array, Order, pipe, String } from 'effect'
 
-/**
- * One entry on the shared status line. `text` must be plain (un-styled) text —
- * the whole row is dimmed uniformly so segments from different plugins share
- * one look.
- */
 export interface StatuslineSegment {
+  /** Plain text: the whole row is dimmed uniformly across plugins. */
   readonly text: string
   readonly align: 'left' | 'right'
 }
@@ -19,72 +15,29 @@ const REGISTRY_KEY = Symbol.for('@pi-plugins/statusline-registry')
 
 type Registry = Map<string, StatuslineSegment>
 
-function registry(): Registry {
-  const store = globalThis as { [REGISTRY_KEY]?: Registry }
-  store[REGISTRY_KEY] ??= new Map()
-  return store[REGISTRY_KEY]
-}
-
-const byKey = Order.mapInput(
-  Order.String,
-  ([key]: readonly [string, StatuslineSegment]) => key,
-)
-
 function side(segments: Registry, align: StatuslineSegment['align']): string {
   return pipe(
     Array.fromIterable(segments),
     Array.filter(([, segment]) => segment.align === align),
-    Array.sortBy(byKey),
+    Array.sortBy(
+      Order.mapInput(
+        Order.String,
+        ([key]: readonly [string, StatuslineSegment]) => key,
+      ),
+    ),
     Array.map(([, segment]) => segment.text),
     Array.join(' · '),
   )
 }
 
-/** Terminal columns of plain text (code points, no ANSI). */
-function textWidth(text: string): number {
-  return Array.fromIterable(text).length
-}
-
-function truncate(text: string, columns: number): string {
-  return pipe(Array.fromIterable(text), Array.take(columns), Array.join(''))
-}
-
-/**
- * Lays out `left ... right` across `width`: left indented one column to match
- * pi's built-in widget rows, right flush against the terminal edge to match
- * pi's footer. Falls back to one truncated `left · right` run when too narrow.
- */
-function renderLine(segments: Registry, width: number, theme: Theme): string {
-  const left = side(segments, 'left')
-  const right = side(segments, 'right')
-
-  const margin = Math.min(width, 1)
-  const inner = width - margin
-  const gap = inner - textWidth(left) - textWidth(right)
-  const minGap = String.isNonEmpty(left) && String.isNonEmpty(right) ? 2 : 0
-
-  const line =
-    String.isNonEmpty(right) && gap >= minGap
-      ? `${left}${' '.repeat(gap)}${right}`
-      : truncate(
-          pipe([left, right], Array.filter(String.isNonEmpty), Array.join(' · ')),
-          Math.max(inner, 0),
-        )
-
-  return ' '.repeat(margin) + theme.fg('dim', line)
-}
-
-/**
- * Adds, replaces (`segment`), or removes (`undefined`) a keyed segment on a
- * single status line above the editor shared across pi-plugins extensions,
- * instead of each plugin stacking its own widget row.
- */
 export function setStatuslineSegment(
   ctx: ExtensionContext,
   key: string,
   segment: StatuslineSegment | undefined,
 ): void {
-  const segments = registry()
+  const store = globalThis as { [REGISTRY_KEY]?: Registry }
+  store[REGISTRY_KEY] ??= new Map()
+  const segments = store[REGISTRY_KEY]
   if (segment === undefined) {
     segments.delete(key)
   } else {
@@ -101,7 +54,31 @@ export function setStatuslineSegment(
   }
 
   ctx.ui.setWidget(WIDGET_KEY, (_tui, theme) => ({
-    render: (width: number) => [renderLine(segments, width, theme)],
     invalidate: () => {},
+    render: (width: number) => {
+      const left = side(segments, 'left')
+      const right = side(segments, 'right')
+
+      // Left indented one column like pi's widget rows, right flush like pi's footer.
+      const margin = Math.min(width, 1)
+      const inner = width - margin
+      const gap =
+        inner - Array.fromIterable(left).length - Array.fromIterable(right).length
+      const minGap = String.isNonEmpty(left) && String.isNonEmpty(right) ? 2 : 0
+
+      const line =
+        String.isNonEmpty(right) && gap >= minGap
+          ? `${left}${' '.repeat(gap)}${right}`
+          : pipe(
+              [left, right],
+              Array.filter(String.isNonEmpty),
+              Array.join(' · '),
+              Array.fromIterable,
+              Array.take(Math.max(inner, 0)),
+              Array.join(''),
+            )
+
+      return [' '.repeat(margin) + theme.fg('dim', line)]
+    },
   }))
 }

--- a/tooling/shared/src/ui.ts
+++ b/tooling/shared/src/ui.ts
@@ -13,13 +13,6 @@ import {
 import type { Component } from '@earendil-works/pi-tui'
 import { Text, truncateToWidth } from '@earendil-works/pi-tui'
 
-function expandHint(hidden: number, theme: Theme): string {
-  return `${theme.fg('muted', `... (${hidden} more lines,`)} ${keyHint(
-    'app.tools.expand',
-    'to expand',
-  )})`
-}
-
 export interface TextPreviewOptions {
   text: string
   maxLines: number
@@ -28,10 +21,6 @@ export interface TextPreviewOptions {
   color?: ThemeColor
 }
 
-/**
- * Previews `text` capped at `maxLines` lines as the terminal wraps them at the
- * real render width, so a long paragraph does not preview as a wall of text.
- */
 export class TextPreview implements Component {
   private readonly body: Text
   private readonly maxLines: number
@@ -45,7 +34,7 @@ export class TextPreview implements Component {
     theme,
     color = 'dim',
   }: TextPreviewOptions) {
-    // Color per source line: wrapping re-emits the codes on each visual line.
+    // Styled per source line so wrapping re-emits the color on each visual line.
     const styled = text
       .split('\n')
       .map((line) => theme.fg(color, line))
@@ -66,14 +55,14 @@ export class TextPreview implements Component {
     if (this.expanded || hidden <= 0) {
       return lines
     }
-    return [
-      ...lines.slice(0, this.maxLines),
-      truncateToWidth(expandHint(hidden, this.theme), width, '...'),
-    ]
+    const hint = `${this.theme.fg('muted', `... (${hidden} more lines,`)} ${keyHint(
+      'app.tools.expand',
+      'to expand',
+    )})`
+    return [...lines.slice(0, this.maxLines), truncateToWidth(hint, width, '...')]
   }
 }
 
-/** Joins all text blocks of a tool result into one string, stripping carriage returns. */
 export function getTextOutput(
   result: Pick<AgentToolResult<unknown>, 'content'>,
 ): string {
@@ -92,11 +81,6 @@ export interface ExpandableTextOptions {
   truncation?: TruncationResult
 }
 
-/**
- * Renders a `header` above its `content`, previewed at `maxLines` unless
- * `expanded`. Trailing blank lines are dropped and a `truncation` notice footer
- * is added when provided.
- */
 export class ExpandableText implements Component {
   private readonly parts: Component[]
 
@@ -139,10 +123,6 @@ export class ExpandableText implements Component {
   }
 }
 
-/**
- * Builds a human-readable notice describing how a result was truncated (by line
- * or byte limit), or an empty string when it was not truncated.
- */
 export function formatTruncationNotice(truncation: TruncationResult): string {
   let result = ''
 


### PR DESCRIPTION
Applies the code style section added to `AGENTS.md` (zero comments by default, inline single-use logic) to every plugin and tooling package. `plugins/claude-oauth/scripts/claude-trace.ts` is deliberately left untouched.

## Comments
Removed everything that restates the code: JSDoc on functions/types/schema fields, section banners, "what this does" narration, and rationale already visible from control flow. Kept and condensed only what cannot be inferred:
- Cross-plugin/cross-process contracts (`Symbol.for` statusline registry, `PI_CACHE_RETENTION=short` handshake between `subagent` and `claude-oauth`, the token-field constraint for pi's auto-compaction)
- External quirks (`userInfo()` throwing in sandboxes, linkedom's unset `location`, `pi` exiting on an empty `--name`, epoch-second `resets_at`)
- Statistical/protocol rationale (`speed/service.ts` estimator, `cch` canonicalization, fingerprint formulas, the `user_id` identity envelope)
- Guards against plausible wrong edits (pi's `Working...` label must match, why a lone delta is rejected, why `millis > 0` needs no check)

## Inlined single-use helpers
- `tooling/shared`: `expandHint`, `registry`, `byKey`, `truncate`, `renderLine`, `ABORT_MESSAGE`
- `speed`: `formatTps`
- `usage`: `bar`×2, `renderSection`, `windowRow`, `formatIdentifier`, `reset`, `claudeLimitLabel`
- `checkpoint`: `restoreTree`
- `claude-oauth`: `installCchFetchWrapper`, `mapStainlessArch/Os`, `createBillingHeader`, `configurePayloadCacheTtls`, `isPiInternalParagraph`
- `fast-mode`: `modelKey`
- `subagent`: `subagentSessionDir`, `modelPattern`, `resolvePiInvocation`, `initialState`
- `webfetch`: `shouldConvertToMarkdown`

Kept as functions after a second pass (see the second commit): anything with 2+ call sites, coherent units like `weightedMedian`/`streamedTokens`/`foldMessage`/`formatRow`/`formatDuration`, and helpers whose inlined form would have been a nested ternary, a `let`+`break` inside a loop, or a closure 4–5 levels deep (`unifiedLimitLabel`, `codexWindowName`/`Label`, `accountIdFromToken`, `breakIfStale`).

## Behavior
No runtime changes. One dead branch removed in `subagent`: `pi.getThinkingLevel()` is typed to always return a level, so the `undefined` case in the model pattern was unreachable.

Rebased on #56 and #58.

`ci` (format, lint, type-check, build, test) passes: 45/45.
