### PR TITLE
refactor(speed): simplify approximate speed estimates

### DIFF
--- a/.changeset/honest-speed-estimates.md
+++ b/.changeset/honest-speed-estimates.md
@@ -1,0 +1,8 @@
+---
+'@pi-plugins/speed': patch
+---
+
+Always mark throughput as approximate instead of inferring certainty from agreement
+between requests. Remove the confidence estimator and unused Effect service wrapper.
+Ignore empty chunks for timing, exclude stale measurements when updating the display,
+and only show estimates for the selected model.

--- a/.changeset/honest-speed-estimates.md
+++ b/.changeset/honest-speed-estimates.md
@@ -2,7 +2,4 @@
 '@pi-plugins/speed': patch
 ---
 
-Always mark throughput as approximate instead of inferring certainty from agreement
-between requests. Remove the confidence estimator and unused Effect service wrapper.
-Ignore empty chunks for timing, exclude stale measurements when updating the display,
-and only show estimates for the selected model.
+Simplify speed estimates and fix timing, stale samples, and model switching.

--- a/plugins/speed/README.md
+++ b/plugins/speed/README.md
@@ -2,7 +2,8 @@
 
 A [pi-agent](https://github.com/earendil-works/pi) extension that shows how fast the
 current model is generating — tokens per second and time to first token — on a shared
-status line above the editor.
+status line above the editor. The rate is a smoothed estimate from recent completed
+responses for the selected model.
 
 ## Install
 

--- a/plugins/speed/README.md
+++ b/plugins/speed/README.md
@@ -27,5 +27,5 @@ pi -e ./plugins/speed
 There is nothing to run. The status line keeps itself up to date:
 
 ```text
-48 tok/s · TTFT 920ms
+~48 tok/s · TTFT 920ms
 ```

--- a/plugins/speed/package.json
+++ b/plugins/speed/package.json
@@ -39,9 +39,10 @@
   "scripts": {
     "prepack": "pnpm run build",
     "build": "tsdown",
-    "check": "pnpm run lint && pnpm run check-types && pnpm run format:check",
+    "check": "pnpm run lint && pnpm run check-types && pnpm run format:check && pnpm run test",
     "check-types": "tsc -b",
     "lint": "oxlint",
+    "test": "node --test test/*.test.ts",
     "format": "oxfmt",
     "format:check": "oxfmt --check"
   },

--- a/plugins/speed/src/index.ts
+++ b/plugins/speed/src/index.ts
@@ -1,15 +1,22 @@
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 import { setStatuslineSegment } from '@pi-plugins/shared/statusline'
-import { Effect } from 'effect'
 import { recentText, streamingText } from './render'
-import { SpeedTracker } from './service'
+import { createSpeedTracker, type FirstToken } from './service'
 
 const SEGMENT_KEY = 'speed'
 
 export default function speed(pi: ExtensionAPI) {
-  const tracker = Effect.runSync(SpeedTracker.make)
+  const tracker = createSpeedTracker()
 
-  function showWidget(ctx: ExtensionContext, text: string | undefined): void {
+  function showWidget(ctx: ExtensionContext, firstToken?: FirstToken): void {
+    const recent =
+      ctx.model === undefined
+        ? undefined
+        : tracker.recent(`${ctx.model.provider}/${ctx.model.id}`)
+    const text =
+      firstToken === undefined
+        ? recentText(recent)
+        : streamingText(recent, firstToken)
     setStatuslineSegment(
       ctx,
       SEGMENT_KEY,
@@ -19,7 +26,15 @@ export default function speed(pi: ExtensionAPI) {
 
   pi.on('session_start', (_event, ctx) => {
     tracker.reset()
-    showWidget(ctx, undefined)
+    showWidget(ctx)
+  })
+
+  pi.on('model_select', (_event, ctx) => {
+    showWidget(ctx)
+  })
+
+  pi.on('turn_start', (_event, ctx) => {
+    showWidget(ctx)
   })
 
   pi.on('before_provider_request', () => {
@@ -35,8 +50,12 @@ export default function speed(pi: ExtensionAPI) {
       streamEvent.type === 'thinking_delta' ? 'thinking' : 'visible',
       streamEvent.delta.length,
     )
-    if (firstToken !== undefined) {
-      showWidget(ctx, streamingText(tracker.recent(), firstToken))
+    if (
+      firstToken !== undefined &&
+      streamEvent.partial.provider === ctx.model?.provider &&
+      streamEvent.partial.model === ctx.model?.id
+    ) {
+      showWidget(ctx, firstToken)
     }
   })
 
@@ -51,7 +70,6 @@ export default function speed(pi: ExtensionAPI) {
       outputTokens: message.usage.output,
       reasoningTokens: message.usage.reasoning,
     })
-    const recent = tracker.recent()
-    showWidget(ctx, recent === undefined ? undefined : recentText(recent))
+    showWidget(ctx)
   })
 }

--- a/plugins/speed/src/render.ts
+++ b/plugins/speed/src/render.ts
@@ -12,15 +12,15 @@ function formatMs(ms: number): string {
 }
 
 function recentTps(recent: RecentSpeed): string {
-  // Two significant figures: the standard error is a few percent, so more digits
-  // would be noise.
   const tps =
     recent.tps < 100 ? Math.round(recent.tps) : Math.round(recent.tps / 10) * 10
-  return `${recent.provisional ? '~' : ''}${tps} tok/s`
+  return `~${tps} tok/s`
 }
 
-export function recentText(recent: RecentSpeed): string {
-  return `${recentTps(recent)} · TTFT ${formatMs(recent.ttftMs)}`
+export function recentText(recent: RecentSpeed | undefined): string | undefined {
+  return recent === undefined
+    ? undefined
+    : `${recentTps(recent)} · TTFT ${formatMs(recent.ttftMs)}`
 }
 
 export function streamingText(

--- a/plugins/speed/src/service.ts
+++ b/plugins/speed/src/service.ts
@@ -1,44 +1,20 @@
-import { Array, Context, Effect, Order } from 'effect'
-
 const MAX_SAMPLES = 1000
 
-// Decay in generated tokens, not requests (a burst of tiny tool-call steps would
-// flush a good estimate) or wall-clock (the number would drift while idle).
+// Token-space decay keeps tiny tool calls from flushing the estimate or idle time
+// from changing its value.
 const HALF_LIFE_TOKENS = 4000
-
 const MIN_WEIGHT = 1e-3
-
-// Token-space decay only ages a model while it generates, so a window left behind
-// by a model switch or an idle session would otherwise read as current forever.
 const MAX_SAMPLE_AGE_MS = 30 * 60 * 1000
 
-// Effective sample size by leverage, not request count: twenty tool-call steps
-// beside one long answer are worth barely more than one observation.
-const MIN_EFFECTIVE_SAMPLES = 5
-
-// Hysteresis: a single threshold flickered as heavy requests left the window.
-const SETTLED_RELATIVE_ERROR = 0.05
-const UNSETTLED_RELATIVE_ERROR = 0.15
-
-// Bartlett lags for the serial-correlation term. Past two the weights are noise.
-const HAC_LAGS = 2
-
-// A sample carrying the whole window leaves no residual to correct against.
-const MAX_LEVERAGE = 0.99
-
-// Share of billed reasoning the streamed thinking must cover to count as streamed
-// whole. Chars-per-token varies ~20% between prose, code and JSON, so anything under
-// this gap is a summary, not measurement noise.
+// Visible and thinking text have different token densities; allow for that when
+// distinguishing fully streamed reasoning from a summary.
 const REASONING_STREAMED = 0.6
-
-// Below this the chunks were flushed from a buffer, not generated.
 const MIN_OBSERVED_MS = 2
 
 export type DeltaKind = 'thinking' | 'visible'
 
 interface Sample {
   readonly model: string
-  /** Monotonic: a wall clock can step backwards. */
   readonly recordedAt: number
   readonly ttftMs: number
   readonly generationMs: number
@@ -46,10 +22,8 @@ interface Sample {
 }
 
 export interface RecentSpeed {
-  readonly model: string
   readonly tps: number
   readonly ttftMs: number
-  readonly provisional: boolean
 }
 
 export interface FirstToken {
@@ -72,246 +46,151 @@ interface InflightRequest {
   thinkingChars: number
 }
 
-// Splits total weight rather than count and is `NaN` when empty.
-function weightedMedian(
-  entries: readonly { readonly value: number; readonly weight: number }[],
-): number {
-  const sorted = Array.sort(
-    entries,
-    Order.mapInput(Order.Number, (entry: (typeof entries)[number]) => entry.value),
-  )
-  const half = sorted.reduce((total, entry) => total + entry.weight, 0) / 2
-  let seen = 0
-  for (const entry of sorted) {
-    seen += entry.weight
-    if (seen >= half) {
-      return entry.value
-    }
-  }
-  return Number.NaN
-}
-
-// Reasoning is billed under `output` whether or not it streams. Withheld or
-// summarized thinking was produced before the first delta, so counting it would
-// credit work no measured interval covers (up to 2x too fast). Only the thinking
-// that streamed belongs in the numerator, converted back to tokens by this
-// request's visible chars-per-token.
-function streamedTokens(
-  request: InflightRequest,
-  outcome: RequestOutcome,
-): number | undefined {
-  const chars = request.visibleChars + request.thinkingChars
-  const withinInterval = chars - request.firstDeltaChars
-  if (withinInterval <= 0) {
-    return undefined
-  }
-
-  const reasoning = Math.min(outcome.reasoningTokens ?? 0, outcome.outputTokens)
-  const visible = outcome.outputTokens - reasoning
-  const density = visible > 0 ? request.visibleChars / visible : 0
-  const implied = density > 0 ? request.thinkingChars / density : 0
-  // Not clamped to `implied` on every request: that would charge density noise
-  // to models that stream their thinking in full.
-  const streamedReasoning =
-    density <= 0
-      ? request.thinkingChars > 0
-        ? reasoning
-        : 0
-      : implied >= reasoning * REASONING_STREAMED
-        ? reasoning
-        : implied
-
-  // The first delta predates the interval, so its share is prorated out by
-  // characters since the opening chunk is routinely a fragment.
-  return ((visible + streamedReasoning) * withinInterval) / chars
-}
-
-// Tokens and milliseconds are summed separately and divided once, so a request
-// counts in proportion to its evidence. Averaging per-request rates would give a
-// 30-token tool-call step the same say as a 1500-token answer.
-function recentSpeed(
-  samples: readonly Sample[],
-  settled: boolean,
-): RecentSpeed | undefined {
-  const latest = samples.at(-1)
-  if (latest === undefined) {
-    return undefined
-  }
-
-  const model = latest.model
-  const horizon = latest.recordedAt - MAX_SAMPLE_AGE_MS
-  const window: { readonly weight: number; readonly sample: Sample }[] = []
-  let tokens = 0
-  let millis = 0
-  let distance = 0
-
-  for (let index = samples.length - 1; index >= 0; index--) {
-    const sample = samples[index]!
-    if (sample.model !== model) {
-      continue
-    }
-    if (sample.recordedAt < horizon) {
-      break
-    }
-    const weight = 0.5 ** (distance / HALF_LIFE_TOKENS)
-    if (weight < MIN_WEIGHT) {
-      break
-    }
-    window.push({ weight, sample })
-    tokens += weight * sample.tokens
-    millis += weight * sample.generationMs
-    distance += sample.tokens
-  }
-
-  // `latest` always matches and every sample clears MIN_OBSERVED_MS, so millis > 0.
-  const rate = tokens / millis
-
-  // Taylor-linearized variance of the ratio estimator. Each squared residual is
-  // divided by its own leverage: a request holding half the window's time is
-  // half of what it is compared against and would otherwise fit itself.
-  let independent = 0
-  let leverageSquares = 0
-  const scores: number[] = []
-  for (const { weight, sample } of window) {
-    const leverage = (weight * sample.generationMs) / millis
-    const score = weight * (sample.tokens - rate * sample.generationMs)
-    independent += (score * score) / (1 - Math.min(leverage, MAX_LEVERAGE)) ** 2
-    leverageSquares += leverage * leverage
-    scores.push(score)
-  }
-
-  // Requests in one turn share a provider node, queue position and context
-  // length, so their residuals move together. Bartlett-weighted lags add that
-  // covariance back. The kernel can go negative under alternation, hence the floor.
-  let variance = independent
-  for (let lag = 1; lag <= HAC_LAGS; lag++) {
-    let covariance = 0
-    for (let index = 0; index + lag < scores.length; index++) {
-      covariance += scores[index]! * scores[index + lag]!
-    }
-    variance += 2 * (1 - lag / (HAC_LAGS + 1)) * covariance
-  }
-
-  const relativeError = Math.sqrt(Math.max(variance, independent)) / tokens
-  const effectiveSamples = 1 / leverageSquares
+export function createSpeedTracker() {
+  const samples: Sample[] = []
+  let inflight: InflightRequest | undefined
 
   return {
-    model,
-    tps: rate * 1000,
-    // Median, not latest: a retried request charges its whole backoff to TTFT.
-    ttftMs: weightedMedian(
-      window.map((entry) => ({ value: entry.sample.ttftMs, weight: entry.weight })),
-    ),
-    // The sample floor gates unconditionally: a window rebuilt from one request
-    // fits it exactly, and its zero residual would hold the latch open on nothing.
-    provisional: !(
-      effectiveSamples >= MIN_EFFECTIVE_SAMPLES &&
-      relativeError <= (settled ? UNSETTLED_RELATIVE_ERROR : SETTLED_RELATIVE_ERROR)
-    ),
+    beginRequest(): void {
+      // Compaction and branch summaries share this hook, but not message events.
+      if (inflight?.firstTokenAt !== undefined) {
+        return
+      }
+      inflight = {
+        requestStart: performance.now(),
+        firstDeltaChars: 0,
+        visibleChars: 0,
+        thinkingChars: 0,
+      }
+    },
+
+    recordDelta(kind: DeltaKind, length: number): FirstToken | undefined {
+      const request = inflight
+      if (request === undefined || length === 0) {
+        return undefined
+      }
+
+      const now = performance.now()
+      if (kind === 'thinking') {
+        request.thinkingChars += length
+      } else {
+        request.visibleChars += length
+      }
+
+      if (request.firstTokenAt !== undefined) {
+        request.lastDeltaAt = now
+        return undefined
+      }
+
+      request.firstTokenAt = now
+      request.firstDeltaChars = length
+      return { ttftMs: now - request.requestStart }
+    },
+
+    endRequest(outcome: RequestOutcome): void {
+      const request = inflight
+      inflight = undefined
+
+      if (
+        request?.firstTokenAt === undefined ||
+        request.lastDeltaAt === undefined ||
+        outcome.stopReason === 'error' ||
+        outcome.stopReason === 'aborted' ||
+        outcome.outputTokens <= 0
+      ) {
+        return
+      }
+
+      const generationMs = request.lastDeltaAt - request.firstTokenAt
+      if (generationMs < MIN_OBSERVED_MS) {
+        return
+      }
+
+      // Billed output includes hidden reasoning. Estimate only the portion that
+      // streamed, using this request's visible characters per token.
+      const reasoning = Math.min(outcome.reasoningTokens ?? 0, outcome.outputTokens)
+      const visible = outcome.outputTokens - reasoning
+      const density = visible > 0 ? request.visibleChars / visible : 0
+      const implied = density > 0 ? request.thinkingChars / density : 0
+      const streamedReasoning =
+        density <= 0
+          ? request.thinkingChars > 0
+            ? reasoning
+            : 0
+          : implied >= reasoning * REASONING_STREAMED
+            ? reasoning
+            : implied
+
+      // The opening chunk predates the measured interval; remove its share.
+      const chars = request.visibleChars + request.thinkingChars
+      const tokens =
+        ((visible + streamedReasoning) * (chars - request.firstDeltaChars)) / chars
+      if (tokens <= 0) {
+        return
+      }
+
+      samples.push({
+        model: outcome.model,
+        recordedAt: request.lastDeltaAt,
+        ttftMs: request.firstTokenAt - request.requestStart,
+        generationMs,
+        tokens,
+      })
+      if (samples.length > MAX_SAMPLES) {
+        samples.shift()
+      }
+    },
+
+    recent(model: string): RecentSpeed | undefined {
+      const horizon = performance.now() - MAX_SAMPLE_AGE_MS
+      const window: { readonly weight: number; readonly sample: Sample }[] = []
+      let tokens = 0
+      let millis = 0
+      let distance = 0
+      let totalWeight = 0
+
+      for (let index = samples.length - 1; index >= 0; index--) {
+        const sample = samples[index]!
+        if (sample.recordedAt < horizon) {
+          break
+        }
+        if (sample.model !== model) {
+          continue
+        }
+        const weight = 0.5 ** (distance / HALF_LIFE_TOKENS)
+        if (weight < MIN_WEIGHT) {
+          break
+        }
+        window.push({ weight, sample })
+        tokens += weight * sample.tokens
+        millis += weight * sample.generationMs
+        distance += sample.tokens
+        totalWeight += weight
+      }
+
+      if (millis === 0) {
+        return undefined
+      }
+
+      // Weighted median keeps a retried request's backoff from dominating TTFT.
+      window.sort((a, b) => a.sample.ttftMs - b.sample.ttftMs)
+      let seen = 0
+      let ttftMs = 0
+      for (const entry of window) {
+        seen += entry.weight
+        if (seen >= totalWeight / 2) {
+          ttftMs = entry.sample.ttftMs
+          break
+        }
+      }
+
+      // Divide the sums, not per-request rates: long responses carry more evidence.
+      return { tps: (tokens / millis) * 1000, ttftMs }
+    },
+
+    reset(): void {
+      samples.length = 0
+      inflight = undefined
+    },
   }
 }
-
-export class SpeedTracker extends Context.Service<SpeedTracker>()(
-  '@pi-plugins/speed/SpeedTracker',
-  {
-    make: Effect.sync(() => {
-      const samples: Sample[] = []
-      let inflight: InflightRequest | undefined
-      let settled = false
-
-      function beginRequest(): void {
-        // Compaction and branch summarization stream through this hook too, so
-        // one can fire mid-turn and must not re-anchor a request already streaming.
-        if (inflight?.firstTokenAt !== undefined) {
-          return
-        }
-        inflight = {
-          requestStart: performance.now(),
-          firstDeltaChars: 0,
-          visibleChars: 0,
-          thinkingChars: 0,
-        }
-      }
-
-      function recordDelta(kind: DeltaKind, length: number): FirstToken | undefined {
-        const request = inflight
-        if (request === undefined) {
-          return undefined
-        }
-
-        const now = performance.now()
-        if (kind === 'thinking') {
-          request.thinkingChars += length
-        } else {
-          request.visibleChars += length
-        }
-
-        if (request.firstTokenAt !== undefined) {
-          request.lastDeltaAt = now
-          return undefined
-        }
-
-        request.firstTokenAt = now
-        request.firstDeltaChars = length
-        return { ttftMs: now - request.requestStart }
-      }
-
-      function endRequest(outcome: RequestOutcome): void {
-        const request = inflight
-        inflight = undefined
-
-        if (
-          request?.firstTokenAt === undefined ||
-          request.lastDeltaAt === undefined ||
-          outcome.stopReason === 'error' ||
-          outcome.stopReason === 'aborted' ||
-          outcome.outputTokens <= 0
-        ) {
-          // A lone delta spans no interval. Timing it would read as thousands of tok/s.
-          return
-        }
-
-        const generationMs = request.lastDeltaAt - request.firstTokenAt
-        if (generationMs < MIN_OBSERVED_MS) {
-          return
-        }
-
-        const tokens = streamedTokens(request, outcome)
-        if (tokens === undefined || tokens <= 0) {
-          return
-        }
-
-        samples.push({
-          model: outcome.model,
-          recordedAt: request.lastDeltaAt,
-          ttftMs: request.firstTokenAt - request.requestStart,
-          generationMs,
-          tokens,
-        })
-        if (samples.length >= MAX_SAMPLES * 2) {
-          samples.splice(0, samples.length - MAX_SAMPLES)
-        }
-      }
-
-      function recent(): RecentSpeed | undefined {
-        const speed = recentSpeed(samples, settled)
-        settled = speed !== undefined && !speed.provisional
-        return speed
-      }
-
-      function reset(): void {
-        samples.length = 0
-        inflight = undefined
-        settled = false
-      }
-
-      return {
-        beginRequest,
-        recordDelta,
-        endRequest,
-        recent,
-        reset,
-      } as const
-    }),
-  },
-) {}

--- a/plugins/speed/src/service.ts
+++ b/plugins/speed/src/service.ts
@@ -52,10 +52,6 @@ export function createSpeedTracker() {
 
   return {
     beginRequest(): void {
-      // Compaction and branch summaries share this hook, but not message events.
-      if (inflight?.firstTokenAt !== undefined) {
-        return
-      }
       inflight = {
         requestStart: performance.now(),
         firstDeltaChars: 0,

--- a/plugins/speed/test/speed.test.ts
+++ b/plugins/speed/test/speed.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { recentText, streamingText } from '../src/render.ts'
+import { createSpeedTracker } from '../src/service.ts'
+
+const outcome = {
+  model: 'provider/model',
+  stopReason: 'stop',
+  outputTokens: 100,
+  reasoningTokens: undefined,
+}
+
+test('times nonempty chunks, excludes the opening chunk and ignores teardown', (t) => {
+  let now = 0
+  t.mock.method(performance, 'now', () => now)
+  const tracker = createSpeedTracker()
+  tracker.beginRequest()
+  now = 100
+  assert.equal(tracker.recordDelta('thinking', 0), undefined)
+  now = 1000
+  assert.deepEqual(tracker.recordDelta('visible', 4), { ttftMs: 1000 })
+  now = 1500
+  tracker.beginRequest()
+  now = 2000
+  tracker.recordDelta('visible', 396)
+  now = 3000
+  tracker.recordDelta('visible', 0)
+  now = 5000
+  tracker.endRequest(outcome)
+  assert.deepEqual(tracker.recent(outcome.model), { tps: 99, ttftMs: 1000 })
+})
+
+for (const scenario of [
+  { name: 'error', stopReason: 'error', outputTokens: 100, duration: 1000 },
+  { name: 'abort', stopReason: 'aborted', outputTokens: 100, duration: 1000 },
+  { name: 'missing usage', stopReason: 'stop', outputTokens: 0, duration: 1000 },
+  { name: 'buffer flush', stopReason: 'stop', outputTokens: 100, duration: 1 },
+  {
+    name: 'single chunk',
+    stopReason: 'stop',
+    outputTokens: 100,
+    duration: undefined,
+  },
+]) {
+  test(`does not report throughput for ${scenario.name}`, (t) => {
+    let now = 0
+    t.mock.method(performance, 'now', () => now)
+    const tracker = createSpeedTracker()
+    tracker.beginRequest()
+    now = 1000
+    tracker.recordDelta('visible', 4)
+    if (scenario.duration !== undefined) {
+      now += scenario.duration
+      tracker.recordDelta('visible', 396)
+    }
+    now += 1000
+    tracker.recordDelta('thinking', 0)
+    tracker.endRequest({ ...outcome, ...scenario })
+    assert.equal(tracker.recent(outcome.model), undefined)
+  })
+}
+
+for (const scenario of [
+  { name: 'withheld reasoning', thinkingChars: 0, tps: 49.5 },
+  { name: 'summarized reasoning', thinkingChars: 40, tps: 54.5 },
+  { name: 'fully streamed reasoning', thinkingChars: 400, tps: 99.5 },
+]) {
+  test(`accounts for ${scenario.name}`, (t) => {
+    let now = 0
+    t.mock.method(performance, 'now', () => now)
+    const tracker = createSpeedTracker()
+    tracker.beginRequest()
+    now = 1000
+    tracker.recordDelta('visible', 4)
+    now = 2000
+    tracker.recordDelta('thinking', scenario.thinkingChars)
+    now = 3000
+    tracker.recordDelta('visible', 396)
+    tracker.endRequest({ ...outcome, outputTokens: 200, reasoningTokens: 100 })
+    assert.deepEqual(tracker.recent(outcome.model), {
+      tps: scenario.tps,
+      ttftMs: 1000,
+    })
+  })
+}
+
+test('smooths tokens and duration separately and keeps models isolated', (t) => {
+  let now = 0
+  t.mock.method(performance, 'now', () => now)
+  const tracker = createSpeedTracker()
+  tracker.beginRequest()
+  now = 100
+  tracker.recordDelta('visible', 4)
+  now = 1100
+  tracker.recordDelta('visible', 4000)
+  tracker.endRequest({ ...outcome, outputTokens: 1001 })
+
+  tracker.beginRequest()
+  now = 1200
+  tracker.recordDelta('visible', 4)
+  now = 2200
+  tracker.recordDelta('visible', 400)
+  tracker.endRequest({ ...outcome, model: 'other/model', outputTokens: 101 })
+  assert.equal(tracker.recent('other/model')?.tps, 100)
+  assert.equal(tracker.recent(outcome.model)?.tps, 1000)
+  assert.equal(tracker.recent('unknown/model'), undefined)
+
+  tracker.beginRequest()
+  now = 2400
+  tracker.recordDelta('visible', 4)
+  now = 2500
+  tracker.recordDelta('visible', 40)
+  tracker.endRequest({ ...outcome, outputTokens: 11 })
+  const weight = 0.5 ** (10 / 4000)
+  assert.deepEqual(tracker.recent(outcome.model), {
+    tps: ((1000 * weight + 10) / (1000 * weight + 100)) * 1000,
+    ttftMs: 200,
+  })
+})
+
+test('expires idle measurements and clears history and inflight state on reset', (t) => {
+  let now = 0
+  t.mock.method(performance, 'now', () => now)
+  const tracker = createSpeedTracker()
+  tracker.beginRequest()
+  now = 1000
+  tracker.recordDelta('visible', 4)
+  now = 2000
+  tracker.recordDelta('visible', 396)
+  tracker.endRequest(outcome)
+  assert.equal(tracker.recent(outcome.model)?.tps, 99)
+
+  now += 30 * 60 * 1000 + 1
+  assert.equal(tracker.recent(outcome.model), undefined)
+  tracker.beginRequest()
+  now += 1000
+  tracker.recordDelta('visible', 4)
+  now += 2000
+  tracker.recordDelta('visible', 396)
+  tracker.endRequest(outcome)
+  assert.equal(tracker.recent(outcome.model)?.tps, 49.5)
+
+  tracker.beginRequest()
+  now += 1000
+  tracker.recordDelta('visible', 4)
+  tracker.reset()
+  assert.equal(tracker.recent(outcome.model), undefined)
+  now += 1000
+  assert.equal(tracker.recordDelta('visible', 396), undefined)
+  tracker.endRequest(outcome)
+  assert.equal(tracker.recent(outcome.model), undefined)
+})
+
+test('labels rates as approximate and shows current TTFT while streaming', () => {
+  const recent = { tps: 48.4, ttftMs: 920 }
+  assert.equal(recentText(recent), '~48 tok/s · TTFT 920ms')
+  assert.equal(recentText({ tps: 123, ttftMs: 1230 }), '~120 tok/s · TTFT 1.23s')
+  assert.equal(streamingText(recent, { ttftMs: 100 }), '~48 tok/s · TTFT 100ms')
+  assert.equal(streamingText(undefined, { ttftMs: 100 }), 'TTFT 100ms')
+  assert.equal(recentText(undefined), undefined)
+})

--- a/plugins/speed/test/speed.test.ts
+++ b/plugins/speed/test/speed.test.ts
@@ -19,8 +19,6 @@ test('times nonempty chunks, excludes the opening chunk and ignores teardown', (
   assert.equal(tracker.recordDelta('thinking', 0), undefined)
   now = 1000
   assert.deepEqual(tracker.recordDelta('visible', 4), { ttftMs: 1000 })
-  now = 1500
-  tracker.beginRequest()
   now = 2000
   tracker.recordDelta('visible', 396)
   now = 3000

--- a/plugins/speed/tsconfig.json
+++ b/plugins/speed/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

A status-line estimate does not need a statistical confidence system: consistent chunk timings can still be biased by buffering and hidden reasoning.

- Remove confidence calculations, settling hysteresis, and the unused Effect service wrapper; always mark throughput with `~`.
- Preserve token-weighted smoothing, recent median TTFT, and streaming/reasoning corrections.
- Ignore empty deltas, expire stale samples on updates, and scope the display to the selected model.
- Add 12 deterministic regression tests and a patch changeset.

## Validation

- `ci` passed all 46 tasks before branching.
- All 12 speed regression tests passed.
- Built-extension smoke test passed for first-token timing, model switches, unusable responses, and idle expiry.