### PR TITLE
feat(subagent): honour PI_SUBAGENT_SESSION_DIR for subagent sessions

### DIFF
--- a/.changeset/subagent-session-dir.md
+++ b/.changeset/subagent-session-dir.md
@@ -1,0 +1,8 @@
+---
+'@pi-plugins/subagent': minor
+---
+
+Honour `PI_SUBAGENT_SESSION_DIR` as the directory subagent sessions are written
+to. Unset, they land in `sessions/subagents/` under pi's agent directory as
+before. A harness that archives a run can now keep the delegated sessions beside
+the parent's instead of losing them to the global directory.

--- a/.changeset/subagent-session-dir.md
+++ b/.changeset/subagent-session-dir.md
@@ -4,5 +4,4 @@
 
 Honour `PI_SUBAGENT_SESSION_DIR` as the directory subagent sessions are written
 to. Unset, they land in `sessions/subagents/` under pi's agent directory as
-before. A harness that archives a run can now keep the delegated sessions beside
-the parent's instead of losing them to the global directory.
+before.

--- a/plugins/subagent/README.md
+++ b/plugins/subagent/README.md
@@ -48,6 +48,14 @@ pi --session <id>
 Subagent sessions are separate from your main session list. Pi offers to fork the
 selected session into your current directory when you open it.
 
+They are written to `sessions/subagents/` under pi's agent directory. Set
+`PI_SUBAGENT_SESSION_DIR` to write them somewhere else, for example next to the
+parent session when a harness archives a run:
+
+```bash
+PI_SUBAGENT_SESSION_DIR=./run-1/subagents pi -p --session ./run-1/session.jsonl "..."
+```
+
 ## Notes
 
 Subagents can edit the same files as your main session. Explicitly ask for a

--- a/plugins/subagent/src/index.ts
+++ b/plugins/subagent/src/index.ts
@@ -101,11 +101,17 @@ export default function subagent(pi: ExtensionAPI) {
       // `pi --tools read`) from being escaped through a child with default tools.
       const tools = pi.getActiveTools().filter((name) => name !== 'subagent')
 
+      // Beside pi's per-project `--<cwd>--` directories, so child sessions stay
+      // out of `pi -c` / `pi -r` but resolve by id from anywhere. A harness
+      // that archives a run points the variable at a directory it keeps.
+      const configured = process.env['PI_SUBAGENT_SESSION_DIR']
+      const sessionDir = configured
+        ? path.resolve(configured)
+        : path.join(getAgentDir(), 'sessions', 'subagents')
+
       const program = runSubagent({
         prompt: params.prompt,
-        // Beside pi's per-project `--<cwd>--` directories, so child sessions stay
-        // out of `pi -c` / `pi -r` but resolve by id from anywhere.
-        sessionDir: path.join(getAgentDir(), 'sessions', 'subagents'),
+        sessionDir,
         name: params.description,
         model,
         cwd,

--- a/plugins/subagent/src/index.ts
+++ b/plugins/subagent/src/index.ts
@@ -102,8 +102,7 @@ export default function subagent(pi: ExtensionAPI) {
       const tools = pi.getActiveTools().filter((name) => name !== 'subagent')
 
       // Beside pi's per-project `--<cwd>--` directories, so child sessions stay
-      // out of `pi -c` / `pi -r` but resolve by id from anywhere. A harness
-      // that archives a run points the variable at a directory it keeps.
+      // out of `pi -c` / `pi -r` but resolve by id from anywhere.
       const configured = process.env['PI_SUBAGENT_SESSION_DIR']
       const sessionDir = configured
         ? path.resolve(configured)


### PR DESCRIPTION
## Summary

Subagent sessions always landed in `sessions/subagents/` under pi's agent directory. A harness that archives a run (such as the cms-ingest eval runner in `k3dom/ndk`) keeps the parent session next to the run but lost every delegated session to that global directory.

- `PI_SUBAGENT_SESSION_DIR`, when set, names the directory the `--session-dir` of each child points at. Relative values resolve against the parent process cwd. Unset, behaviour is unchanged.
- README documents the variable under Sessions.
- Changeset: minor bump of `@pi-plugins/subagent`.

## Verification

`pnpm --filter @pi-plugins/subagent run check` and `build` pass. Pi creates a missing session dir itself (`SessionManager` `mkdirSync` recursive), so the harness only needs to set the variable.